### PR TITLE
Fixed FAQ untagged images deletion from Powershell

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -77,7 +77,7 @@ az acr repository show-manifests -n myRegistry --repository myRepository --query
 
 For Powershell
 ```
-az acr repository show-manifests -n myRegistry --repository myRepository --query "[?tags==null].digest" -o tsv | %{ az acr repository delete -n myRegistry -t myRepository@$_ }
+az acr repository show-manifests -n myRegistry --repository myRepository --query "[?tags==null].digest" -o tsv | %{ az acr repository delete -n myRegistry --image myRepository@$_ }
 ```
 
 Note: You can add `-y` in the delete command to skip confirmation


### PR DESCRIPTION
Dunno why but `-t` option shortcut doesn't work anymore for `az acr repository delete` command in Powershell  
And by the way, bash delete command is ok (-t works fine) but there should be some issue with piping the delete commands after the show-manifest : doesn't delete anything, but didn't have time to investigate this specific matter.