### PR TITLE
Fix untagged manifest query

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -72,12 +72,12 @@ az acr show -n myRegistry --query storageAccount
 
 If you are on bash
 ```
-az acr repository show-manifests -n myRegistry --repository myRepository --query "[?tags==null].digest" -o tsv  | xargs -I% az acr repository delete -n myRegistry -t myRepository@%
+az acr repository show-manifests -n myRegistry --repository myRepository --query "[?tags[0]==null].digest" -o tsv  | xargs -I% az acr repository delete -n myRegistry -t myRepository@%
 ```
 
 For Powershell
 ```
-az acr repository show-manifests -n myRegistry --repository myRepository --query "[?tags==null].digest" -o tsv | %{ az acr repository delete -n myRegistry -t myRepository@$_ }
+az acr repository show-manifests -n myRegistry --repository myRepository --query "[?tags[0]==null].digest" -o tsv | %{ az acr repository delete -n myRegistry -t myRepository@$_ }
 ```
 
 Note: You can add `-y` in the delete command to skip confirmation


### PR DESCRIPTION
This is due to a change from the server side that untagged manifests used to return `null` for `tags` field but now the return value is an empty array such as

```
[
  {
    "digest": "sha256:92c7f9c92844bbbb5d0a101b22f7c2a7949e40f8ea90c8b3bc396879d95e899a",
    "tags": [],
    "timestamp": "2019-01-09T03:21:58.3968339Z"
  }
]
```