### PR TITLE
Modify helm chart config media type

### DIFF
--- a/docs/artifact-media-types.json
+++ b/docs/artifact-media-types.json
@@ -1,6 +1,6 @@
 {
     "application/vnd.docker.distribution.manifest.v2+json": "Docker images",
-    "application/vnd.cncf.helm.config.v3+json": "Helm artifacts",
+    "application/vnd.cncf.helm.chart.config.v3+json": "Helm artifacts",
     "application/vnd.oci.image.config.v1+json": "OCI images",
     "application/vnd.sylabs.sif.config.v1+json": "Singularity images"
 }


### PR DESCRIPTION
Adding `.chart.` to the config media type for Helm charts, as Helm client may want to specify more package types in the future (plugins etc.)

cc @sajayantony @SteveLasker 