### PR TITLE
Modify Helm chart media type

### DIFF
--- a/docs/artifact-media-types.json
+++ b/docs/artifact-media-types.json
@@ -1,6 +1,6 @@
 {
     "application/vnd.docker.distribution.manifest.v2+json": "Docker images",
-    "application/vnd.cncf.helm.chart.config.v3+json": "Helm artifacts",
+    "application/vnd.cncf.helm.chart.config.v1+json": "Helm charts",
     "application/vnd.oci.image.config.v1+json": "OCI images",
     "application/vnd.sylabs.sif.config.v1+json": "Singularity images"
 }


### PR DESCRIPTION
I've switched the media type for helm (again, sorry) based on the discussion here: https://github.com/helm/helm/pull/5719

I've also switched the description from "Helm artifacts" to "Helm charts" - given that Helm may choose to store things such as plugins as well in the future (which would also qualify as an artifact but have a separate media type)