### PR TITLE
Add support for storing Open Policy Agent bundles as OCI artifacts

### DIFF
--- a/docs/artifact-media-types.json
+++ b/docs/artifact-media-types.json
@@ -2,5 +2,6 @@
     "application/vnd.docker.distribution.manifest.v2+json": "Docker images",
     "application/vnd.cncf.helm.chart.config.v3+json": "Helm artifacts",
     "application/vnd.oci.image.config.v1+json": "OCI images",
+    "application/vnd.cncf.openpolicyagent.config.v1+json": "Open Policy Agent bundles",
     "application/vnd.sylabs.sif.config.v1+json": "Singularity images"
 }


### PR DESCRIPTION
Open Policy Agent bundles consist of a set of rego policy files,
JSON or YAML formatted data and an optional JSON formatted manifest
file with metadata about the bundle. This media type allows us to
support distributing OPA bundles as OCI images as well as simple tar files.

For the discussion of this in more detail see https://github.com/open-policy-agent/opa/issues/1413