### PR TITLE
Health Check URL typo fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repo contains [issues](https://github.com/Azure/acr/issues), [samples](./do
 | [Tiers](https://aka.ms/acr/tiers) | https://aka.ms/acr/tiers |
 | [Authentication](https://aka.ms/acr/authentication) | https://aka.ms/acr/authentication |
 | [Authorization Roles](https://aka.ms/acr/authentication/roles) | https://aka.ms/acr/authentication/roles |
-| [Health Check CLI](https://aka.ms/acr/health-check) | https://aka.ms/acr//health-check |
+| [Health Check CLI](https://aka.ms/acr/health-check) | https://aka.ms/acr/health-check |
 | [Tasks](https://aka.ms/acr/tasks) | https://aka.ms/acr/tasks |
 | [Task Scheduling](http://aka.ms/acr/tasks/scheduling) | http://aka.ms/acr/tasks/scheduling |
 | [Task Timer Cron Expressions](http://aka.ms/acr/tasks/cron) | http://aka.ms/acr/tasks/cron |


### PR DESCRIPTION
Updating "Health Check CLI URL" from https://aka.ms/acr//health-check to https://aka.ms/acr/health-check

@sajayantony 