### PR TITLE
Base64 encoding using powershell or terminal

### DIFF
--- a/docs/Token-BasicAuth.md
+++ b/docs/Token-BasicAuth.md
@@ -45,7 +45,7 @@ With this information we're now ready to call `GET /oauth2/token` to obtain an A
     - Encode using the following format: **[username]**:**[password]**
     - Powershell: 
     	- `[convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('[username]:[password]'))`
-    - Linx/Mac Terminal: 
+    - Linux/Mac Terminal: 
     	- `echo '[username]:[password]' | base64`
     - Copy the encoded value and set it as a environment variable
 	

--- a/docs/Token-BasicAuth.md
+++ b/docs/Token-BasicAuth.md
@@ -46,7 +46,7 @@ With this information we're now ready to call `GET /oauth2/token` to obtain an A
     - Powershell: 
     	- `[convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('[username]:[password]'))`
     - Linux/Mac Terminal: 
-    	- `echo '[username]:[password]' | base64`
+    	- `echo -n '[username]:[password]' | base64`
     - Copy the encoded value and set it as a environment variable
 	
 ```bash

--- a/docs/Token-BasicAuth.md
+++ b/docs/Token-BasicAuth.md
@@ -41,8 +41,12 @@ The body of the payload might provide additional details, but all the informatio
 With this information we're now ready to call `GET /oauth2/token` to obtain an ACR access token that will allow us to use the `GET /v2/hello-world/manifests/latest` API. 
 
 ### Encode the username and password 
-  - using a tool like https://www.base64encode.org/
+  - You can use Windows Powershell or `base64` command line utility in Linux/Mac
     - Encode using the following format: **[username]**:**[password]**
+    - Powershell: 
+    	- `[convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('[username]:[password]'))`
+    - Linx/Mac Terminal: 
+    	- `echo '[username]:[password]' | base64`
     - Copy the encoded value and set it as a environment variable
 	
 ```bash


### PR DESCRIPTION

GitHub Issue: https://github.com/Azure/acr/issues/291
Encoding base64 string in powershell/terminal instead of using the URL https://www.base64encode.org/ 