### PR TITLE
Add KV secret access policy in the deployment of ExportPipeline and ImportPipeline

### DIFF
--- a/docs/image-transfer/ExportPipelines/azuredeploy.json
+++ b/docs/image-transfer/ExportPipelines/azuredeploy.json
@@ -38,10 +38,16 @@
         "description": "The target URI of the export pipeline."
       }
     },
-    "keyVaultUri": {
+    "keyVaultName": {
       "type": "string",
       "metadata": {
-        "description": "The key vault secret uri to obtain the target storage SAS token."
+        "description": "The key vault name to obtain the target storage SAS token."
+      }
+    },
+    "sasTokenSecretName": {
+      "type": "string",
+      "metadata": {
+        "description": "The key vault secret name to obtain the target storage SAS token."
       }
     },
     "options": {
@@ -61,7 +67,10 @@
       "userAssignedIdentities": {
         "[parameters('userAssignedIdentity')]": {}
       }
-    }
+    },
+    "keyVaultSecretsPermissions": [
+      "get"
+    ]
   },
   "resources": [
     {
@@ -95,9 +104,28 @@
         "target": {
           "type": "[variables('targetType')]",
           "uri": "[parameters('targetUri')]",
-          "keyVaultUri": "[parameters('keyVaultUri')]"
+          "keyVaultUri": "[concat(reference(resourceId('Microsoft.KeyVault/vaults', parameters('KeyVaultName')), '2019-09-01').vaultUri, 'secrets/', parameters('sasTokenSecretName'))]"
         },
         "options": "[parameters('options')]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/accessPolicies",
+      "name": "[concat(parameters('keyVaultName'), '/add')]",
+      "apiVersion": "2019-09-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerRegistry/registries/exportPipelines', parameters('registryName'), parameters('exportPipelineName'))]"
+      ],
+      "properties": {
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[if(not(empty(parameters('userAssignedIdentity'))), reference(parameters('userAssignedIdentity'), '2018-11-30').principalId, reference(resourceId('Microsoft.ContainerRegistry/registries/exportPipelines', parameters('registryName'), parameters('exportPipelineName')), '2019-12-01-preview', 'Full').identity.principalId)]",
+            "permissions": {
+              "secrets": "[variables('keyVaultSecretsPermissions')]"
+            }
+          }
+        ]
       }
     }
   ]

--- a/docs/image-transfer/ExportPipelines/azuredeploy.parameters.json
+++ b/docs/image-transfer/ExportPipelines/azuredeploy.parameters.json
@@ -11,8 +11,11 @@
     "targetUri": {
       "value": "https://accountname.blob.core.windows.net/containername"
     },
-    "keyVaultUri": {
-      "value": "https://myvault.vault.azure.net/secrets/acrexportsas"
+    "keyVaultName": {
+      "value": "myvault"
+    },
+    "sasTokenSecretName": {
+      "value": "acrexportsas"
     },
     "options": {
       "value": [

--- a/docs/image-transfer/ImportPipelines/azuredeploy.json
+++ b/docs/image-transfer/ImportPipelines/azuredeploy.json
@@ -38,10 +38,16 @@
         "description": "The source URI of the import pipeline."
       }
     },
-    "keyVaultUri": {
+    "keyVaultName": {
       "type": "string",
       "metadata": {
-        "description": "The key vault secret uri to obtain the source storage SAS token."
+        "description": "The key vault name to obtain the target storage SAS token."
+      }
+    },
+    "sasTokenSecretName": {
+      "type": "string",
+      "metadata": {
+        "description": "The key vault secret name to obtain the target storage SAS token."
       }
     },
     "sourceTriggerStatus": {
@@ -72,7 +78,10 @@
       "userAssignedIdentities": {
         "[parameters('userAssignedIdentity')]": {}
       }
-    }
+    },
+    "keyVaultSecretsPermissions": [
+      "get"
+    ]
   },
   "resources": [
     {
@@ -106,7 +115,7 @@
         "source": {
           "type": "[variables('sourceType')]",
           "uri": "[parameters('sourceUri')]",
-          "keyVaultUri": "[parameters('keyVaultUri')]"
+          "keyVaultUri": "[concat(reference(resourceId('Microsoft.KeyVault/vaults', parameters('KeyVaultName')), '2019-09-01').vaultUri, 'secrets/', parameters('sasTokenSecretName'))]"
         },
         "trigger": {
           "sourceTrigger": {
@@ -114,6 +123,25 @@
           }
         },
         "options": "[parameters('options')]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/accessPolicies",
+      "name": "[concat(parameters('keyVaultName'), '/add')]",
+      "apiVersion": "2019-09-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerRegistry/registries/importPipelines', parameters('registryName'), parameters('importPipelineName'))]"
+      ],
+      "properties": {
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[if(not(empty(parameters('userAssignedIdentity'))), reference(parameters('userAssignedIdentity'), '2018-11-30').principalId, reference(resourceId('Microsoft.ContainerRegistry/registries/importPipelines', parameters('registryName'), parameters('importPipelineName')), '2019-12-01-preview', 'Full').identity.principalId)]",
+            "permissions": {
+              "secrets": "[variables('keyVaultSecretsPermissions')]"
+            }
+          }
+        ]
       }
     }
   ]

--- a/docs/image-transfer/ImportPipelines/azuredeploy.parameters.json
+++ b/docs/image-transfer/ImportPipelines/azuredeploy.parameters.json
@@ -11,8 +11,11 @@
     "sourceUri": {
       "value": "https://accountname.blob.core.windows.net/containername"
     },
-    "keyVaultUri": {
-      "value": "https://myvault.vault.azure.net/secrets/acrimportsas"
+    "keyVaultName": {
+      "value": "myvault"
+    },
+    "sasTokenSecretName": {
+      "value": "acrimportsas"
     },
     "options": {
       "value": [


### PR DESCRIPTION
We support either a system-assigned identity or a user-assigned identity for each ExportPipeline and ImportPipeline. The pipeline resources need to use the identity to access users' key vault to get the storage sas token secret.

The change adds the pipeline resource's identity to the key vault access policy in the same template.

To extract the principal ID of the system or user assigned identity of the deployed pipeline resource, we leverage the "reference' template function: https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource#reference

Key vault also exposes access policy as a resource "Microsoft.KeyVault/vaults/accessPolicies" so that we can add via the template: https://github.com/Azure/azure-quickstart-templates/blob/master/101-keyvault-add-access-policy/azuredeploy.json