### PR TITLE
Add default values to pipeline templates

### DIFF
--- a/docs/image-transfer/ExportPipelines/azuredeploy.json
+++ b/docs/image-transfer/ExportPipelines/azuredeploy.json
@@ -54,7 +54,8 @@
       "type": "array",
       "metadata": {
         "description": "The list of all options configured for the pipeline."
-      }
+      },
+      "defaultValue": []
     }
   },
   "variables": {

--- a/docs/image-transfer/ImportPipelines/azuredeploy.json
+++ b/docs/image-transfer/ImportPipelines/azuredeploy.json
@@ -65,7 +65,8 @@
       "type": "array",
       "metadata": {
         "description": "The list of all options configured for the pipeline."
-      }
+      },
+      "defaultValue": []
     }
   },
   "variables": {

--- a/docs/image-transfer/PipelineRun/azuredeploy.json
+++ b/docs/image-transfer/PipelineRun/azuredeploy.json
@@ -36,7 +36,7 @@
       "metadata": {
         "description": "List of source artifacts to be transferred by the pipeline."
       },
-      "defaultValue": ""
+      "defaultValue": []
     },
     "sourceName": {
       "type": "string",


### PR DESCRIPTION
Options parameter is not required, so support a default value of empty array.

Fix the default value of artifacts to be an empty array. This parameter is not required to manually run an import pipeline.
