### PR TITLE
Create user assigned identity entry with non-null value

### DIFF
--- a/samples/dotnetcore/image-transfer/ContainerRegistryTransfer/Helpers/IdentityHelper.cs
+++ b/samples/dotnetcore/image-transfer/ContainerRegistryTransfer/Helpers/IdentityHelper.cs
@@ -15,7 +15,7 @@ namespace ContainerRegistryTransfer.Helpers
                     Type = ResourceIdentityType.UserAssigned,
                     UserAssignedIdentities = new Dictionary<string, UserIdentityProperties>
                     {
-                        { userAssignedIdentity, null }
+                        { userAssignedIdentity, new UserIdentityProperties() }
                     }
                 };
             }


### PR DESCRIPTION
When creating a user identity dictionary entry, we cannot use null value or ARM will throw an exception