### PR TITLE
Image transfer sample - Registry Artifact Transfer Tool

### DIFF
--- a/samples/dotnetcore/registry-artifact-transfer/README.md
+++ b/samples/dotnetcore/registry-artifact-transfer/README.md
@@ -1,0 +1,186 @@
+# **Overview of Registry Artifact Transfer Tool** ##
+
+The Registry Artifact Transfer Tool supports transfer workflows that combines both registry artifact import and export. For example, in a single run, it can (1) import artifacts from a source registry as well as storage blobs previously exported by ACR transfer into a target ACR; (2) batch export the artifacts imported in (1) along with any additional artifacts existing in the target ACR into storage blobs; (3) copy the blobs exported in (2) to a destination blob container so that they are ready to be imported to a different ACR.
+
+Please see the public documentation for more details on ACR [Transfer](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-transfer-images) and [Image Import](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-import-images).
+
+### **Features**
+
+1. Import  
+  a. Import registry artifacts from a source registry to a target ACR.  
+  b. Import registry artifacts from storage blobs exported by ACR transfer to a target ACR.
+
+2. Export  
+  a. Export registry artifacts from a target ACR into storage blobs.  
+  b. Optionally, copy the exported storage blobs to another blob container. The copy destination blob container can be hooked up with a different ACR with an import pipeline to effectively transfer the artifacts to the latter, with storage blobs as transfer mediums.
+
+
+# **Prerequisities**
+
+0. **Common**  
+  * An existing target ACR. The ACR must be in [Premium](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-skus) SKU if feature 1b, 2a, or 2b will be used.
+  * A service principle with contributor role of the target ACR.
+
+1. **Import**  
+    a. Import registry artifacts from a source registry to a target ACR.  
+    * **Source container registry**: an existing source container registry with artifacts to transfer. To permit image import from the source registry:
+      * If the source registry is an ACR, either the service principle in the common prerequisities has read permission (e.g. Reader role) to the source ACR or the source ACR's user name and password are available. The user name can be the admin user of the source ACR or the client ID of a service principle with read permission (and client secret as the password). More details on the permission requirement can be found in [this](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-import-images#import-from-another-azure-container-registry) section.
+      * If the source registry is a non-Azure private registry, credentials that enable pull access to the registry need to be available.
+
+    b. Import registry artifacts from storage blobs exported by ACR transfer to a target ACR.
+    * **Source storage blobs**: existing source storage blobs in storage containers exported by ACR [export pipelines](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-transfer-images#create-exportpipeline-with-resource-manager) where the source registry artifacts are contained.
+    * **Import pipeline**: an existing [import pipeline](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-transfer-images#create-importpipeline-with-resource-manager) under the target ACR with valid permission (managed identity and sas token in a key vault) to access the storage blob container where the source blobs are located.
+
+2. **Export**  
+    a. Export registry artifacts from a target ACR to storage blobs.
+    * **Registry artifacts**: existing registry artifacts to be exported from the target ACR.
+    * **Export pipeline**: an existing [export pipeline](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-transfer-images#create-exportpipeline-with-resource-manager) under the target ACR with valid permission (managed identity and sas token in a key vault) to access the storage blob container where the target blobs will be exported.
+
+    b. Copy the exported storage blobs to another blob container.
+    * **Copy destination blob container**: an existing storage blob container where the exported blobs will be copied to.
+    * **SAS tokens**: A SAS token with read access to the export blob container and a SAS token with write access to the copy destination blob container.
+
+
+# **Configurations** ##
+
+The tool uses a single JSON formatted configuration file. The default configuration file name is `transferdefinition.json` and a sample can be found in `src/transferdefinition.json`.
+
+### **Common configurations**
+
+The common configurations consist of the information about the Azure environment, the target ACR, and the service principle used to access the target ACR.
+
+```
+  "AzureEnvironment": {
+    "Name": "AzureGlobalCloud"
+  },
+  "Registry": {
+    "TenantId": "myTenantId",
+    "SubscriptionId": "mySubscriptionId",
+    "ResourceGroupName": "myResourceGroupName",
+    "Name": "myRegistryName"
+  },
+  "Identity": {
+    "ClientId": "myClientId",
+    "ClientSecret": "myClientSecret"
+  },
+```
+
+| Configuration               | Description                                                               |
+|-----------------------------|---------------------------------------------------------------------------|
+| AzureEnvironment/Name       | The name of the Azure environment. The list of the supported names can be found in [this](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.resourcemanager.fluent.azureenvironment?view=azure-dotnet) document. |
+| Registry/TenantId           | The tenant ID of the target ACR.                                          |
+| Registry/SubscriptionId     | The subscription ID of the target ACR.                                    |
+| Registry/ResourceGroupName  | The resource group name of the target ACR.                                |
+| Registry/Name               | The name of the target ACR.                                               |
+| Identity/ClientId           | The client ID of the service principle used to access the target ACR.     |
+| Identity/ClientSecret       | The client secret of the service principle.                               |
+
+
+### **Import configurations**
+
+The import configurations specify:
+* The repositories and tags from a source registry to be imported to the target ACR.
+* The storage blobs to be imported to the target ACR as well as the import pipeline to be used for the import.
+
+```
+  "Import": {
+    "Enabled": true,
+    "Force": true,
+    "SourceRegistry": {
+      "ResourceId": "mySourceRegistryResourceId",
+      "RegistryUri": "mysourceregistry.azurecr.io",
+      "UserName": "clientId-or-adminUser",
+      "Password": "clientSecret-or-adminPassword"
+    },
+    "Repositories": [
+      "sourceRepo",
+      "sourceRepoPrefix*"
+    ],
+    "Tags": [
+      "sourceRepo1:tag1",
+      "sourceRepo2:tag2"
+    ],
+    "ImportPipelineName": "myImportPipelineName",
+    "Blobs": [
+      "exportedBlob1",
+      "exportedBlob2",
+      "exportedBlob3"
+    ]
+  },
+```
+
+| Configuration                     | Features  | Description |
+|-----------------------------------|-----------|--------------------------------------------------------------------------|
+| Import/Enabled                    | 1a, 1b    | Configures Whether the import feature is enabled. The default value is `false`. |
+| Import/Force                      | 1a        | Configures whether any existing target tags will be overwritten (see [ImportMode](https://docs.microsoft.com/en-us/rest/api/containerregistry/registries/importimage#importmode)). The default value is `true`.|
+| Import/SourceRegistry/ResourceId  | 1a        | The Azure resource ID of the source registry if it is an ACR. If `ResourceId` is specified, `RegistryUri`, `UserName`, and `Password` must be skipped, and vice versa. The `Identity/ClientId` will be used to access the source ACR. |
+| Import/SourceRegistry/RegistryUri | 1a        | The login server of the source registry, applicable to both ACRs and non-Azure public and private registries. If the source registry is a public registry, `UserName` and `Password` must be skipped. |
+| Import/SourceRegistry/UserName    | 1a        | The user name to access the source registry.                              |
+| Import/SourceRegistry/Password    | 1a        | The password of the user name.                                            |
+| Import/Repositories               | 1a        | The list of repository names and name prefixes to match the repositories in the source registry. All tags in the matched repositories are imported. A repository name prefix can be specified with a `*` after the prefix string |
+| Import/Tags                       | 1a        | The list of tags in the source registry to import.                        |
+| Import/ImportPipelineName         | 1b        | The import pipeline used to import source blobs to the target ACR.        |
+| Import/Blobs                      | 1b        | The source blobs containing the source registry artifacts, previously exported by ACR export pipelines. All blobs must be in the blob container targeted by the specified import pipeline. |
+
+### **Export configurations**
+
+The export configurations specify:
+* The export controls such as batch artifact count and blob name prefix.
+* The repositories and tags from the target ACR to be exported to storage blobs.
+* The blob copy SAS token and URI for the export target blob container and the copy destination blob container, respectively.
+
+```
+  "Export": {
+    "Enabled": true,
+    "ExportPipelineName": "myExportPipelineName",
+    "MaxArtifactCountPerBlob": 50,
+    "BlobNamePrefix": "artifacts",
+    "IncludeImportedArtifacts": true,
+    "Repositories": [
+      "targetRepo",
+      "targetRepoPrefix*"
+    ],
+    "Tags": [
+      "targetRepo1:tag1",
+      "targetRepo2:tag2"
+    ],
+    "CopyBlobs": {
+      "Enabled": true,
+      "SourceSasToken": "sourceBlobContainerSasToken",
+      "DestContainerSasUri": "destinationBlobContainerSasUri"
+    }
+  }
+```
+
+| Configuration                         | Features  | Description |
+|---------------------------------------|-----------|---------------------------------------------------------------------------  |
+| Export/Enabled                        | 2a        | Configures whether the export feature is enabled. The default value is `false`. |
+| Export/ExportPipelineName             | 2a        | The export pipeline under the target ACR to export the specified artifacts. |
+| Export/MaxArtifactCountPerBlob        | 2a        | The maximum batch export artifact count. The default value is `50`.         |
+| Export/BlobNamePrefix                 | 2a        | The name prefix of the export storage blobs.                                |
+| Export/IncludeImportedArtifacts       | 2a        | Configures whether the artifacts imported by 1a and 1b are included in the export. The default value is `false`. |
+| Export/Repositories                   | 2a        | The list of repository names and name prefixes to match the repositories in the target ACR. All tags in the matched repositories are exported. A repository name prefix can be specified with a `*` after the prefix string. |
+| Export/Tags                           | 2a        | The list of tags in the target ACR to export.                               |
+| Export/CopyBlobs/Enabled              | 2b        | Configures whether the blob copy feature is enabled.                        |
+| Export/CopyBlobs/SourceSasToken       | 2b        | The SAS token of the blob container targed by the specified export pipeline.|
+| Export/CopyBlobs/DestContainerSasUri  | 2b        | The SAS URI of the copy destination blob container.                         |
+
+
+# **Running the tool** ##
+* Build the project (.NET Core SDK 3.1 required)
+```
+dotnet build src/RegistryArtifactTransfer.csproj
+```
+
+* Run the tool with the default configuration file transferdefinition.json
+```
+cd src/bin/Debug/netcoreapp3.1
+dotnet RegistryArtifactTransfer.dll
+```
+
+* Run the tool with a custom configuration file name  
+Copy the configuration file to src/bin/Debug/netcoreapp3.1 and run
+```
+cd src/bin/Debug/netcoreapp3.1
+dotnet RegistryArtifactTransfer.dll myTransferDefinition.json
+```

--- a/samples/dotnetcore/registry-artifact-transfer/src/Configurations/AzureEnvironmentConfiguration.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Configurations/AzureEnvironmentConfiguration.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace RegistryArtifactTransfer
+{
+    public class AzureEnvironmentConfiguration
+    {
+        public string Name { get; set; }
+        public string AuthenticationEndpoint { get; set; }
+        public string ManagementEndpoint { get; set; }
+        public string ResourceManagerEndpoint { get; set; }
+        public string GraphEndpoint { get; set; }
+        public string KeyVaultSuffix { get; set; }
+        public string StorageEndpointSuffix { get; set; }
+
+        public void Validate()
+        {
+            if (string.IsNullOrWhiteSpace(Name))
+            {
+                throw new ArgumentNullException(nameof(Name));
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Configurations/ExportConfiguration.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Configurations/ExportConfiguration.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+
+namespace RegistryArtifactTransfer
+{
+    public class ExportConfiguration
+    {
+        public bool Enabled { get; set; }
+        public bool IncludeImportedArtifacts { get; set; }
+        public string ExportPipelineName { get; set; }
+        public string BlobNamePrefix { get; set; }
+        public int MaxConcurrency { get; set; } = 50;
+        public int MaxArtifactCountPerBlob { get; set; } = 50;
+        public int TransferTimeoutInSeconds { get; set; } = 300;
+        public List<string> Repositories { get; set; } = new List<string>();
+        public List<string> Tags { get; set; } = new List<string>();
+        public CopyBlobsConfiguration CopyBlobs { get; set; }
+
+        public void Validate()
+        {
+            if (!Enabled)
+            {
+                return;
+            }
+
+            if (MaxConcurrency < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MaxConcurrency), MaxConcurrency, "must be larger than 0");
+            }
+
+            if (MaxArtifactCountPerBlob < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MaxArtifactCountPerBlob), MaxArtifactCountPerBlob, "must be larger than 0");
+            }
+
+            if (TransferTimeoutInSeconds < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(TransferTimeoutInSeconds), TransferTimeoutInSeconds, "must be larger than 0");
+            }
+
+            if (string.IsNullOrWhiteSpace(ExportPipelineName))
+            {
+                throw new ArgumentNullException(nameof(ExportPipelineName));
+            }
+
+            if (string.IsNullOrWhiteSpace(BlobNamePrefix))
+            {
+                throw new ArgumentNullException(nameof(BlobNamePrefix));
+            }
+
+            CopyBlobs.Validate();
+        }
+    }
+
+    public class CopyBlobsConfiguration
+    {
+        public bool Enabled { get; set; }
+        public string DestContainerSasUri { get; set; }
+        public string SourceSasToken { get; set; }
+
+        public void Validate()
+        {
+            if (!Enabled)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(DestContainerSasUri))
+            {
+                throw new ArgumentNullException(nameof(DestContainerSasUri));
+            }
+
+            if (string.IsNullOrWhiteSpace(SourceSasToken))
+            {
+                throw new ArgumentNullException(nameof(SourceSasToken));
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Configurations/IdentityConfiguration.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Configurations/IdentityConfiguration.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace RegistryArtifactTransfer
+{
+    public class IdentityConfiguration
+    {
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+
+        public void Validate()
+        {
+            if (string.IsNullOrWhiteSpace(ClientId))
+            {
+                throw new ArgumentNullException(nameof(ClientId));
+            }
+
+            if (string.IsNullOrWhiteSpace(ClientSecret))
+            {
+                throw new ArgumentNullException(nameof(ClientSecret));
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Configurations/ImportConfiguration.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Configurations/ImportConfiguration.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace RegistryArtifactTransfer
+{
+    public class ImportConfiguration
+    {
+        public bool Enabled { get; set; }
+        public bool Force { get; set; } = true;
+        public int MaxConcurrency { get; set; } = 50;
+        public int TransferTimeoutInSeconds { get; set; } = 300;
+        public SourceRegistryConfiguration SourceRegistry { get; set; }
+        public List<string> Repositories { get; set; } = new List<string>();
+        public List<string> Tags { get; set; } = new List<string>();
+        public string ImportPipelineName { get; set; }
+        public List<string> Blobs { get; set; }
+
+        public void Validate()
+        {
+            if (!Enabled)
+            {
+                return;
+            }
+
+            if (MaxConcurrency < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MaxConcurrency), MaxConcurrency, "must be larger than 0");
+            }
+
+            if (TransferTimeoutInSeconds < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(TransferTimeoutInSeconds), TransferTimeoutInSeconds, "must be larger than 0");
+            }
+
+            if (SourceRegistry == null)
+            {
+                throw new ArgumentNullException(nameof(SourceRegistry));
+            }
+
+            SourceRegistry.Validate();
+
+            if (string.IsNullOrWhiteSpace(SourceRegistry.RegistryUri) && (Repositories != null && Repositories.Count > 0))
+            {
+                throw new ArgumentException($"{nameof(SourceRegistry.RegistryUri)} must be specified to import {nameof(Repositories)}");
+            }
+
+            if (string.IsNullOrWhiteSpace(ImportPipelineName) && Blobs != null && Blobs.Count > 0)
+            {
+                throw new ArgumentNullException(nameof(ImportPipelineName));
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Configurations/RegistryConfiguration.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Configurations/RegistryConfiguration.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace RegistryArtifactTransfer
+{
+    public class RegistryConfiguration
+    {
+        public string TenantId { get; set; }
+        public string SubscriptionId { get; set; }
+        public string ResourceGroupName { get; set; }
+        public string Name { get; set; }
+
+        public void Validate()
+        {
+            if (string.IsNullOrWhiteSpace(TenantId))
+            {
+                throw new ArgumentNullException(nameof(TenantId));
+            }
+
+            if (string.IsNullOrWhiteSpace(SubscriptionId))
+            {
+                throw new ArgumentNullException(nameof(SubscriptionId));
+            }
+
+            if (string.IsNullOrWhiteSpace(ResourceGroupName))
+            {
+                throw new ArgumentNullException(nameof(ResourceGroupName));
+            }
+
+            if (string.IsNullOrWhiteSpace(Name))
+            {
+                throw new ArgumentNullException(nameof(Name));
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Configurations/SourceRegistryConfiguration.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Configurations/SourceRegistryConfiguration.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace RegistryArtifactTransfer
+{
+    public class SourceRegistryConfiguration
+    {
+        public string ResourceId { get; set; }
+        public string RegistryUri { get; set; }
+        public string UserName { get; set; }
+        public string Password { get; set; }
+
+        public void Validate()
+        {
+            if (!string.IsNullOrWhiteSpace(ResourceId))
+            {
+                if (!string.IsNullOrWhiteSpace(RegistryUri) ||
+                    !string.IsNullOrWhiteSpace(UserName) ||
+                    !string.IsNullOrWhiteSpace(Password))
+                {
+                    throw new ArgumentException($"{nameof(RegistryUri)}, {nameof(UserName)}, or {nameof(Password)} cannot be used with {nameof(ResourceId)}.");
+                }
+            }
+            else if (string.IsNullOrWhiteSpace(RegistryUri))
+            {
+                throw new ArgumentException($"Either {nameof(RegistryUri)} or {nameof(ResourceId)} must be specified.");
+            }
+            else if (string.IsNullOrWhiteSpace(UserName) ^ string.IsNullOrWhiteSpace(Password))
+            {
+                throw new ArgumentException($"Either {nameof(UserName)} or {nameof(Password)} is missing.");
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Configurations/TransferDefinition.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Configurations/TransferDefinition.cs
@@ -1,0 +1,20 @@
+namespace RegistryArtifactTransfer
+{
+    public class TransferDefinition
+    {
+        public AzureEnvironmentConfiguration AzureEnvironment { get; set; }
+        public IdentityConfiguration Identity { get; set; }
+        public RegistryConfiguration Registry { get; set; }
+        public ImportConfiguration Import { get; set; }
+        public ExportConfiguration Export { get; set; }
+
+        public void Validate()
+        {
+            AzureEnvironment.Validate();
+            Identity.Validate();
+            Registry.Validate();
+            Import.Validate();
+            Export.Validate();
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Program.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Program.cs
@@ -1,0 +1,119 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Serilog;
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace RegistryArtifactTransfer
+{
+    public static class Program
+    {
+        private const string ReportFileNamePrefix = "report";
+        private const string LogFileNamePrefix = "log";
+
+        public static async Task Main(string[] args)
+        {
+            #region Global HTTP settings
+
+            // https://github.com/Azure/azure-storage-net-data-movement#best-practice
+            ServicePointManager.DefaultConnectionLimit = Environment.ProcessorCount * 8;
+            ServicePointManager.Expect100Continue = false;
+
+            #endregion
+
+            #region Logger
+
+            var logFileName = LogFileNamePrefix + "_" + string.Format("{0:yyyy-MM-dd_HH-mm-ss-fff}", DateTimeOffset.Now) + ".txt";
+            var loggerFactory = LoggerFactory.Create(builder => builder.AddSerilog(new LoggerConfiguration()
+                .WriteTo.File(logFileName)
+                .WriteTo.ColoredConsole()
+                .CreateLogger()));
+            var logger = loggerFactory.CreateLogger("RegistryArtifactTransfer");
+
+            #endregion
+
+            #region Configurations
+
+            string transferDefinitionFile = args.Length > 0
+                ? args[0]
+                : Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "transferdefinition.json");
+            var transferDefinition = GetConfig(transferDefinitionFile);
+            transferDefinition.Validate();
+
+            var azureEnvironmentConfiguration = transferDefinition.AzureEnvironment;
+            var identityConfiguration = transferDefinition.Identity;
+            var registryConfiguration = transferDefinition.Registry;
+
+            #endregion
+
+            #region TransferClient
+
+            var transferClient = new TransferClient(
+                azureEnvironmentConfiguration,
+                identityConfiguration,
+                registryConfiguration);
+
+            #endregion
+
+            #region Process transfer
+
+            var report = new TransferReport();
+
+            var importWorker = new ImportWorker(
+                transferDefinition.Import,
+                registryConfiguration,
+                transferClient,
+                loggerFactory.CreateLogger<ImportWorker>());
+
+            var exportWorker = new ExportWorker(
+                transferDefinition.Export,
+                registryConfiguration,
+                identityConfiguration,
+                transferClient,
+                loggerFactory.CreateLogger<ExportWorker>());
+
+            await importWorker.RunAsync(report);
+            await exportWorker.RunAsync(report);
+
+            #endregion
+
+            #region Report results
+
+            logger.LogInformation($"Total artifacts successfully imported: {report.ImportArtifacts.Succeeded.Count}.");
+            logger.LogInformation($"Total artifacts failed to import: {report.ImportArtifacts.Failed.Count}.");
+            logger.LogInformation($"Total blobs successfully exported: {report.ImportBlobs.Succeeded.Count}.");
+            logger.LogInformation($"Total blobs failed to export: {report.ImportBlobs.Failed.Count}.");
+            logger.LogInformation($"Total artifacts successfully exported: {report.ExportArtifacts.Succeeded.Count}.");
+            logger.LogInformation($"Total artifacts failed in exporting: {report.ExportArtifacts.Failed.Count}.");
+            logger.LogInformation($"Total blobs successfully exported: {report.ExportBlobs.Succeeded.Count}.");
+            logger.LogInformation($"Total blobs failed in exporting: {report.ExportBlobs.Failed.Count}.");
+            logger.LogInformation($"Total blobs successfully copied: {report.CopyBlobs.Succeeded.Count}.");
+            logger.LogInformation($"Total blobs failed in copying: {report.CopyBlobs.Failed.Count}.");
+
+            var reportFileName = ReportFileNamePrefix + "_" + string.Format("{0:yyyy-MM-dd_HH-mm-ss-fff}", DateTimeOffset.Now) + ".json";
+            await File.WriteAllTextAsync(reportFileName, JsonConvert.SerializeObject(report, Formatting.Indented));
+
+            #endregion
+
+            logger.LogInformation("Done!");
+        }
+
+        private static TransferDefinition GetConfig(string transferDefinitionFile)
+        {
+
+            var builder = new ConfigurationBuilder()
+                .AddJsonFile(transferDefinitionFile)
+                .AddEnvironmentVariables();
+
+            var transferDefinition = new TransferDefinition();
+
+            builder.Build().Bind(transferDefinition);
+
+            return transferDefinition;
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Registry.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Registry.cs
@@ -1,0 +1,47 @@
+using System;
+using static RegistryArtifactTransfer.ResourceId;
+
+namespace RegistryArtifactTransfer
+{
+    public class Registry
+    {
+        public ResourceId ResourceId { get; }
+        public string TenantId { get; }
+        public string LoginServer { get; }
+        public string UserName { get; }
+        public string Password { get; }
+
+        public Registry(
+            string tenantId,
+            string subscriptionId,
+            string resourceGroupName,
+            string registryName)
+        {
+            ResourceId = new ResourceId(subscriptionId, resourceGroupName, registryName, RegistriesARMResourceType);
+            TenantId = tenantId;
+        }
+
+        public Registry(
+            string loginServer,
+            string userName,
+            string password)
+        {
+            LoginServer = loginServer;
+            UserName = userName;
+            Password = password;
+        }
+
+        public void Validate()
+        {
+            if (ResourceId == null && string.IsNullOrEmpty(LoginServer))
+            {
+                throw new ArgumentException($"Neither {nameof(ResourceId)} nor {nameof(LoginServer)} is specified.");
+            }
+
+            if (string.IsNullOrEmpty(UserName) ^ string.IsNullOrEmpty(Password))
+            {
+                throw new ArgumentException($"{nameof(UserName)} and {nameof(Password)} should either be both specified or undeclared.");
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/RegistryArtifactTransfer.csproj
+++ b/samples/dotnetcore/registry-artifact-transfer/src/RegistryArtifactTransfer.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Update="transferdefinition.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Management.ContainerRegistry" Version="5.0.0-preview.5"/>
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.34.0"/>
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="1.3.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4"/>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.4"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4"/>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.4"/>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1"/>
+    <PackageReference Include="Polly" Version="7.2.0"/>
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0"/>
+    <PackageReference Include="Serilog" Version="2.9.0"/>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0"/>
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1"/>
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0"/>
+  </ItemGroup>
+</Project>

--- a/samples/dotnetcore/registry-artifact-transfer/src/RepositoryProvider/CatalogApiResponse.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/RepositoryProvider/CatalogApiResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace RegistryArtifactTransfer
+{
+    public class CatalogApiResponse
+    {
+        [JsonProperty(PropertyName = "repositories")]
+        public List<string> Repositories;
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/RepositoryProvider/HttpMessageExtensions.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/RepositoryProvider/HttpMessageExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace RegistryArtifactTransfer
+{
+    public static class HttpMessageExtensions
+    {
+        private const string LinkHeaderName = "Link";
+        private const string NextRelationType = "rel=\"next\"";
+
+        public static Uri GetNextPageUri(this HttpResponseMessage response)
+        {
+            if (!response.Headers.Contains(LinkHeaderName))
+            {
+                return null;
+            }
+
+            var headerLink = response.Headers.GetValues(LinkHeaderName);
+            var nextPage = headerLink.FirstOrDefault();
+
+            if (!nextPage.Contains(NextRelationType))
+            {
+                return null;
+            }
+
+            int backwardsPointer = nextPage.IndexOf(NextRelationType);
+            nextPage = nextPage.Substring(nextPage.LastIndexOf('<', backwardsPointer) + 1, nextPage.LastIndexOf('>', backwardsPointer) - 1);
+
+            if (nextPage.StartsWith('/'))
+            {
+                nextPage = nextPage.Substring(1);
+                if (nextPage.StartsWith('/'))
+                {
+                    return null;
+                }
+            }
+
+            if (Uri.TryCreate(nextPage, UriKind.Absolute, out Uri nextPageUri))
+            {
+                if (!string.Equals(nextPageUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(nextPageUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                return nextPageUri;
+            }
+
+            if (Uri.IsWellFormedUriString(nextPage, UriKind.Relative))
+            {
+                var requestUri = response.RequestMessage.RequestUri;
+                var baseUriBuilder = new UriBuilder(requestUri.Scheme, requestUri.Host, requestUri.Port);
+                return new Uri(baseUriBuilder.Uri, nextPage);
+            }
+
+            return null;
+        }
+
+        public static void AddBasicAuth(this HttpRequestMessage request, string userName, string password)
+        {
+            if (!string.IsNullOrWhiteSpace(userName) && !string.IsNullOrWhiteSpace(password))
+            {
+                var svcCredentials = Convert.ToBase64String(Encoding.UTF8.GetBytes(userName + ":" + password));
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", svcCredentials);
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/RepositoryProvider/RepositoryProviderV2.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/RepositoryProvider/RepositoryProviderV2.cs
@@ -1,0 +1,139 @@
+﻿using Newtonsoft.Json;
+using Polly;
+using Polly.Extensions.Http;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace RegistryArtifactTransfer
+{
+    public class RepositoryProviderV2
+    {
+        #region Route constants
+        private const string GetCatalogRoute = "https://{0}/v2/_catalog?n={1}";
+        private const string GetTagsRoute = "https://{0}/v2/{1}/tags/list?n={2}";
+        #endregion
+
+        private const int pageSize = 100;
+
+
+        #region Exponential backoff retry with jitter
+        private readonly TimeSpan initWaitTime = TimeSpan.FromSeconds(2);
+        private readonly int maxRetryCount = 4;
+        private readonly IAsyncPolicy<HttpResponseMessage> retryPolicy;
+        #endregion
+
+        private readonly HttpClient _httpClient;
+
+        public RepositoryProviderV2()
+        {
+            _httpClient = new HttpClient();
+
+            retryPolicy = HttpPolicyExtensions
+                        .HandleTransientHttpError()
+                        .WaitAndRetryAsync(
+                            maxRetryCount,
+                            retryAttempt => TimeSpan.FromSeconds(Math.Pow(initWaitTime.TotalSeconds, retryAttempt))  
+                            + TimeSpan.FromMilliseconds(new Random().Next(0, 100)));
+        }
+
+        public async Task<IEnumerable<string>> GetRepositoriesAsync(
+            string registry,
+            string userName,
+            string password)
+        {
+            if (string.IsNullOrWhiteSpace(registry))
+            {
+                throw new ArgumentNullException(nameof(registry));
+            }
+
+            var repositories = new List<string>();
+
+            var nextPageUri = new Uri(string.Format(GetCatalogRoute, registry, pageSize));
+            while (nextPageUri != null)
+            {
+
+                var response = await retryPolicy.ExecuteAsync(
+                    async () =>
+                    {
+                        using (var request = new HttpRequestMessage(HttpMethod.Get, nextPageUri))
+                        {
+                            request.AddBasicAuth(userName, password);
+                            return await _httpClient.SendAsync(request);
+                        }
+                    });
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var repoPage = JsonConvert.DeserializeObject<CatalogApiResponse>(await response.Content.ReadAsStringAsync())?.Repositories;
+                    if (repoPage != null)
+                    {
+                        repositories.AddRange(repoPage);
+                    }
+
+                    nextPageUri = response.GetNextPageUri();
+                }
+                else
+                {
+                    var content = await response.Content.ReadAsStringAsync();
+                    throw new Exception($"Registry:{registry} failed to list repositories. StatusCode:{response.StatusCode}, Reason:{response.ReasonPhrase}, Content:{content}");
+                }
+            }
+
+            return repositories;
+        }
+
+        public async Task<IEnumerable<string>> GetTagsAsync(
+            string registry,
+            string repository,
+            string userName,
+            string password)
+        {
+            if (string.IsNullOrWhiteSpace(registry))
+            {
+                throw new ArgumentNullException(nameof(registry));
+            }
+
+            if (string.IsNullOrWhiteSpace(repository))
+            {
+                throw new ArgumentNullException(nameof(repository));
+            }
+
+            var tags = new List<string>();
+
+            var nextPageUri = new Uri(string.Format(GetTagsRoute, registry, repository, pageSize));
+            while (nextPageUri != null)
+            {
+                var response = await retryPolicy.ExecuteAsync(
+                    async () =>
+                    {
+                        using (var request = new HttpRequestMessage(HttpMethod.Get, nextPageUri))
+                        {
+                            request.AddBasicAuth(userName, password);
+                            return await _httpClient.SendAsync(request);
+                        }
+                    });
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var tagPage = JsonConvert.DeserializeObject<TagListApiResponse>(await response.Content.ReadAsStringAsync())?.Tags;
+
+                    if (tagPage != null)
+                    {
+                        tags.AddRange(tagPage);
+                    }
+
+                    nextPageUri = response.GetNextPageUri();
+                }
+                else
+                {
+                    var content = await response.Content.ReadAsStringAsync();
+                    throw new Exception($"Registry:{registry} Repository:{repository} failed to list tags. StatusCode:{response.StatusCode}, Reason:{response.ReasonPhrase}, Content:{content}");
+                }
+            }
+
+            return tags;
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/RepositoryProvider/TagListApiResponse.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/RepositoryProvider/TagListApiResponse.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace RegistryArtifactTransfer
+{
+    public class TagListApiResponse
+    {
+        [JsonProperty(PropertyName = "name")]
+        public string Name;
+
+        [JsonProperty(PropertyName = "tags")]
+        public List<string> Tags;
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/ResourceId.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/ResourceId.cs
@@ -1,0 +1,144 @@
+using System;
+
+namespace RegistryArtifactTransfer
+{
+    public class ResourceId
+    {
+        public const string ContainerRegistryProviderNamespace = "Microsoft.ContainerRegistry";
+        public const string RegistriesARMResourceType = ContainerRegistryProviderNamespace + "/registries";
+        public const string ExportPipelineResourceType = "exportPipelines";
+        public const string ImportPipelineResourceType = "importPipelines";
+        public const string PipelineRunResourceType = "pipelineRuns";
+
+        public string SubscriptionId { get; set; }
+
+        public string ResourceGroupName { get; set; }
+
+        public string ResourceName { get; set; }
+
+        public string ArmResourceType { get; set; }
+
+        // Current only support single-level nested resources.
+        public string ChildResourceName { get; set; }
+
+        public string ChildResourceType { get; set; }
+
+        public ResourceId()
+        {
+        }
+
+        public ResourceId(
+            string subscriptionId,
+            string resourceGroupName,
+            string resourceName,
+            string armResourceType)
+        {
+            this.SubscriptionId = subscriptionId ?? throw new ArgumentNullException(nameof(subscriptionId));
+            this.ResourceGroupName = resourceGroupName ?? throw new ArgumentNullException(nameof(resourceGroupName));
+            this.ResourceName = resourceName ?? throw new ArgumentNullException(nameof(resourceName));
+            this.ArmResourceType = armResourceType ?? throw new ArgumentNullException(nameof(armResourceType));
+            this.ChildResourceName = null;
+            this.ChildResourceType = null;
+        }
+
+        public ResourceId(
+            string subscriptionId,
+            string resourceGroupName,
+            string resourceName,
+            string armResourceType,
+            string childResourceType,
+            string childResourceName) :
+            this(
+                subscriptionId,
+                resourceGroupName,
+                resourceName,
+                armResourceType)
+        {
+            this.ChildResourceName = childResourceName ?? throw new ArgumentNullException(nameof(childResourceName));
+            this.ChildResourceType = childResourceType ?? throw new ArgumentNullException(nameof(childResourceType));
+        }
+
+        public static bool TryParse(string value, out ResourceId resourceId)
+        {
+            try
+            {
+                resourceId = Parse(value);
+                return true;
+            }
+            catch (FormatException)
+            {
+                resourceId = default(ResourceId);
+                return false;
+            }
+        }
+
+        public static ResourceId Parse(string value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var components = value.Split('/');
+
+            // The accepted string values are:
+            // "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}"
+            // "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{provideName}/{resourceType}/{resourceName}" 
+            // "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{provideName}/{resourceType}/{resourceName}/{childResourceType}/{childResourceName}" 
+
+            if ((components.Length != 5 && components.Length != 9 && components.Length != 11) ||
+                !string.IsNullOrEmpty(components[0]) ||
+                !string.Equals(components[1], "subscriptions", StringComparison.OrdinalIgnoreCase) ||
+                !string.Equals(components[3], "resourceGroups", StringComparison.OrdinalIgnoreCase) ||
+                (components.Length > 5 &&
+                !string.Equals(components[5], "providers", StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new FormatException("Failed to parse a resource id from the input string: \"" + value + "\"");
+            }
+
+            var resourceId = new ResourceId()
+            {
+                SubscriptionId = components[2],
+                ResourceGroupName = components[4]
+            };
+
+            if (components.Length > 5)
+            {
+                resourceId.ArmResourceType = string.Join("/", components[6], components[7]);
+                resourceId.ResourceName = components[8];
+            }
+
+            if (components.Length > 9)
+            {
+                resourceId.ChildResourceType = components[9];
+                resourceId.ChildResourceName = components[10];
+            }
+
+            return resourceId;
+        }
+
+        public override string ToString()
+        {
+            var resourceIdString = GetParentResourceId();
+
+            if (!string.IsNullOrEmpty(ChildResourceType))
+            {
+                resourceIdString = string.Join("/", resourceIdString, ChildResourceType, ChildResourceName);
+            }
+
+            return resourceIdString;
+        }
+
+        public string GetParentResourceId()
+        {
+            var resourceIdString = string.Join("/", string.Empty, "subscriptions", SubscriptionId, "resourceGroups", ResourceGroupName);
+
+            if (!string.IsNullOrEmpty(ArmResourceType))
+            {
+                resourceIdString = string.Join("/", resourceIdString, "providers", ArmResourceType, ResourceName);
+            }
+
+            return resourceIdString;
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/TaskExtensions.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/TaskExtensions.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RegistryArtifactTransfer
+{
+    public static class TaskExtensions
+    {
+        public static async Task ThrottledWhenAll<T>(
+            this IEnumerable<T> source,
+            Func<T, Task> operation,
+            int maxConcurrency)
+        {
+            var tasks = new List<Task>();
+            using (var throttler = new SemaphoreSlim(maxConcurrency, maxConcurrency))
+            {
+                foreach (var element in source)
+                {
+                    await throttler.WaitAsync().ConfigureAwait(false);
+
+                    tasks.Add(Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await operation(element).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            throttler.Release();
+                        }
+                    }));
+                }
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ArtifactProvider.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ArtifactProvider.cs
@@ -1,0 +1,85 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace RegistryArtifactTransfer
+{
+    public class ArtifactProvider
+    {
+        private readonly ILogger _logger;
+        private readonly RepositoryProviderV2 _repositoryProvider;
+
+        public ArtifactProvider(ILogger logger) : base()
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _repositoryProvider = new RepositoryProviderV2();
+        }
+
+        public async Task<List<string>> GetArtifactsAsync(
+            string registryUri,
+            string userName,
+            string password,
+            List<string> repoFilters)
+        {
+            var artifacts = new List<string>();
+            IEnumerable<string> repositories = null;
+
+            repositories = await _repositoryProvider.GetRepositoriesAsync(
+                registryUri,
+                userName,
+                password).ConfigureAwait(false);
+
+            if (repositories != null)
+            {
+                foreach (var repo in repositories)
+                {
+                    if (Match(repo, repoFilters))
+                    {
+                        _logger.LogInformation($"Repository matched: {repo}");
+                        IEnumerable<string> tags;
+
+                        tags = await _repositoryProvider.GetTagsAsync(
+                            registryUri,
+                            repo,
+                            userName,
+                            password).ConfigureAwait(false);
+
+                        if (tags != null)
+                        {
+                            foreach (var tag in tags)
+                            {
+                                artifacts.Add($"{repo.ToLowerInvariant()}:{tag}");
+                            }
+                        }
+                    }
+                }
+            }
+
+            return artifacts;
+        }
+
+        private static bool Match(
+            string repo,
+            List<string> repoFilters)
+        {
+            foreach (var filter in repoFilters)
+            {
+                if (filter.EndsWith('*'))
+                {
+                    var prefix = filter.Substring(0, filter.Length - 1);
+                    if (repo.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+                else if (string.Equals(repo, filter, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Transfer/BlobCopier.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Transfer/BlobCopier.cs
@@ -1,0 +1,60 @@
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Storage.DataMovement;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RegistryArtifactTransfer
+{
+    public class BlobCopier
+    {
+        private readonly ILogger _logger;
+        private readonly CloudBlobContainer _sourceContainer;
+        private readonly CloudBlobContainer _targetContainer;
+
+        public BlobCopier(
+            Uri sourceContainerSas,
+            Uri targetContainerSas,
+            ILogger logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _sourceContainer = new CloudBlobContainer(sourceContainerSas);
+            _targetContainer = new CloudBlobContainer(targetContainerSas);
+        }
+
+        public async Task CopyAsync(
+            string blobName,
+            CancellationToken token = default(CancellationToken))
+        {
+            var sourceBlob = _sourceContainer.GetBlobReference(blobName);
+            var targetBlob = _targetContainer.GetBlobReference(blobName);
+            TransferCheckpoint checkpoint = null;
+            SingleTransferContext context = GetSingleTransferContext(checkpoint, blobName);
+
+            await TransferManager.CopyAsync(
+                sourceBlob: sourceBlob,
+                destBlob: targetBlob,
+                copyMethod: CopyMethod.ServiceSideAsyncCopy,
+                options: null,
+                context: context,
+                cancellationToken: token).ConfigureAwait(false);
+        }
+
+        private SingleTransferContext GetSingleTransferContext(
+            TransferCheckpoint checkpoint,
+            string blobName)
+        {
+            SingleTransferContext context = new SingleTransferContext(checkpoint);
+
+            context.ShouldOverwriteCallbackAsync = TransferContext.ForceOverwrite;
+
+            context.ProgressHandler = new Progress<TransferStatus>((progress) =>
+            {
+                _logger.LogInformation($"{blobName}: bytes transferred {progress.BytesTransferred}.");
+            });
+
+            return context;
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ExportJob.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ExportJob.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace RegistryArtifactTransfer
+{
+    public class ExportJob
+    {
+        public string ExportPipelineName { get; set; }
+        public string PipelineRunName { get; set; }
+        public string ExportBlobName { get; set; }
+        public List<string> Images { get; set; } = new List<string>();
+        public TransferJobStatus Status { get; set; }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ExportWorker.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ExportWorker.cs
@@ -1,0 +1,221 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RegistryArtifactTransfer
+{
+    public class ExportWorker
+    {
+        private readonly ExportConfiguration _exportConfiguration;
+        private readonly IdentityConfiguration _identityConfiguration;
+        private readonly ILogger _logger;
+        private readonly TransferClient _transferClient;
+        private readonly Registry _registry;
+
+        public ExportWorker(
+            ExportConfiguration exportDefinition,
+            RegistryConfiguration registryConfiguration,
+            IdentityConfiguration identityConfiguration,
+            TransferClient transferClient,
+            ILogger<ExportWorker> logger)
+        {
+            _transferClient = transferClient ?? throw new ArgumentNullException(nameof(transferClient));
+            _exportConfiguration = exportDefinition ?? throw new ArgumentNullException(nameof(exportDefinition));
+            _identityConfiguration = identityConfiguration ?? throw new ArgumentNullException(nameof(identityConfiguration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            _registry = new Registry(
+                registryConfiguration.TenantId,
+                registryConfiguration.SubscriptionId,
+                registryConfiguration.ResourceGroupName,
+                registryConfiguration.Name);
+        }
+
+        public async Task RunAsync(TransferReport transferReport)
+        {
+            if (!_exportConfiguration.Enabled)
+            {
+                return;
+            }
+
+            //
+            // Include imported images
+            var importedImages = new List<string>();
+            if (_exportConfiguration.IncludeImportedArtifacts && transferReport.ImportArtifacts.Succeeded.Count > 0)
+            {
+                importedImages.AddRange(transferReport.ImportArtifacts.Succeeded);
+            }
+
+            if (importedImages.Count == 0 &&
+                _exportConfiguration.Repositories.Count == 0 &&
+                _exportConfiguration.Tags.Count == 0)
+            {
+                return;
+            }
+
+            //
+            // Validate exportPipeline
+            var exportPipeline = await _transferClient.GetExportPipelineAsync(_exportConfiguration.ExportPipelineName).ConfigureAwait(false);
+            if (!exportPipeline.ProvisioningState.Equals("succeeded", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new Exception($"ExportPipeline:{_exportConfiguration.ExportPipelineName} is in non-success provisioning state {exportPipeline.ProvisioningState}.");
+            }
+
+            //
+            // Export images
+            var exportJobs = await CreateExportJobsAsync(importedImages).ConfigureAwait(false);
+
+            await exportJobs.ThrottledWhenAll(
+                async (job) => await ExecuteExportAsync(job).ConfigureAwait(false),
+                _exportConfiguration.MaxConcurrency).ConfigureAwait(false);
+
+            foreach (var job in exportJobs)
+            {
+                if (job.Status == TransferJobStatus.Succeeded)
+                {
+                    transferReport.ExportArtifacts.Succeeded.AddRange(job.Images);
+                    transferReport.ExportBlobs.Succeeded.Add(job.ExportBlobName);
+                }
+                else if (job.Status == TransferJobStatus.Failed)
+                {
+                    transferReport.ExportArtifacts.Failed.AddRange(job.Images);
+                    transferReport.ExportBlobs.Failed.Add(job.ExportBlobName);
+                }
+            }
+
+            //
+            // Copy exported blobs
+            if (_exportConfiguration.CopyBlobs != null &&
+                _exportConfiguration.CopyBlobs.Enabled &&
+                transferReport.ExportBlobs.Succeeded.Count > 0)
+            {
+                var sourceContainerSas = new Uri(await GetSourceSasUriAsync().ConfigureAwait(false));
+                var targetContainerSas = new Uri(_exportConfiguration.CopyBlobs.DestContainerSasUri);
+                var blobCopier = new BlobCopier(sourceContainerSas, targetContainerSas, _logger);
+
+                foreach (var blobName in transferReport.ExportBlobs.Succeeded)
+                {
+                    _logger.LogInformation($"Blob {blobName}: starting to copy .");
+
+                    try
+                    {
+                        await blobCopier.CopyAsync(blobName).ConfigureAwait(false);
+                        transferReport.CopyBlobs.Succeeded.Add(blobName);
+                        _logger.LogInformation($"Blob {blobName}: Successfully copied.");
+                    }
+                    catch (Exception e)
+                    {
+                        transferReport.CopyBlobs.Failed.Add(blobName);
+                        _logger.LogError($"Blob {blobName}: failed to copy, exception: {e}.");
+                    }
+                }
+            }
+        }
+
+        private async Task ExecuteExportAsync(ExportJob exportJob)
+        {
+            try
+            {
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(_exportConfiguration.TransferTimeoutInSeconds)))
+                {
+                    await _transferClient.ExportImagesToStorageAsync(
+                        exportJob.ExportPipelineName,
+                        exportJob.PipelineRunName,
+                        exportJob.Images,
+                        exportJob.ExportBlobName,
+                        cts.Token).ConfigureAwait(false);
+                }
+
+                exportJob.Status = TransferJobStatus.Succeeded;
+                _logger.LogInformation($"PipelineRun {exportJob.PipelineRunName} succeeded.");
+            }
+            catch (Exception e)
+            {
+                exportJob.Status = TransferJobStatus.Failed;
+                _logger.LogError($"PipelineRun {exportJob.PipelineRunName} failed, exception: {e}.");
+            }
+        }
+
+        private async Task<List<ExportJob>> CreateExportJobsAsync(List<string> importedImages)
+        {
+            var exportJobs = new List<ExportJob>();
+            var images = new List<string>();
+
+            var importedImageCount = importedImages?.Count ?? 0;
+            if (importedImageCount > 0)
+            {
+                images.AddRange(importedImages);
+            }
+
+            if (_exportConfiguration.Repositories != null && _exportConfiguration.Repositories.Count > 0)
+            {
+                var artifactProvider = new ArtifactProvider(_logger);
+                var loginServer = await _transferClient.GetRegistryLoginServerAsync().ConfigureAwait(false);
+
+                var matchedTags = await artifactProvider.GetArtifactsAsync(
+                    loginServer,
+                    _identityConfiguration.ClientId,
+                    _identityConfiguration.ClientSecret,
+                    _exportConfiguration.Repositories).ConfigureAwait(false);
+                
+                images.AddRange(matchedTags);
+            }
+
+            if (_exportConfiguration.Tags != null)
+            {
+                images.AddRange(_exportConfiguration.Tags);
+            }
+
+            _logger.LogInformation($"Total artifacts to export: {images.Count}.");
+
+            var i = 0;
+            while (i < images.Count)
+            {
+                if (i % _exportConfiguration.MaxArtifactCountPerBlob == 0)
+                {
+                    var endIndex = Math.Min(i + _exportConfiguration.MaxArtifactCountPerBlob - 1, images.Count - 1);
+                    var pipelineRunName = Guid.NewGuid().ToString("N");
+                    var targetBlobName = $"{_exportConfiguration.BlobNamePrefix}From{i+1}To{endIndex+1}";
+
+                    var job = new ExportJob
+                    {
+                        PipelineRunName = pipelineRunName,
+                        ExportPipelineName = _exportConfiguration.ExportPipelineName,
+                        ExportBlobName = targetBlobName
+                    };
+
+                    while (i <= endIndex)
+                    {
+                        job.Images.Add(images[i]);
+                        i++;
+                    }
+
+                    exportJobs.Add(job);
+                }
+            }
+
+            return exportJobs;
+        }
+
+        private async Task<string> GetSourceSasUriAsync()
+        {
+            var exportPipeline = await _transferClient.GetExportPipelineAsync(_exportConfiguration.ExportPipelineName).ConfigureAwait(false);
+            var blobContainerUri = exportPipeline?.Target?.Uri;
+
+            if (string.IsNullOrWhiteSpace(blobContainerUri))
+            {
+                throw new Exception($"Invalid source blob container URI from export pipeline {exportPipeline}.");
+            }
+
+            var sasToken = _exportConfiguration.CopyBlobs.SourceSasToken;
+            if (!sasToken.StartsWith('?'))
+            {
+                sasToken = "?" + sasToken;
+            }
+
+            return blobContainerUri + sasToken;
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ImportJob.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ImportJob.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace RegistryArtifactTransfer
+{
+    public class ImportJob
+    {
+        public ImportSourceType SourceType { get; set; }
+        public List<string> Images { get; set; } = new List<string>();
+        public string ImportPipelineName { get; set; }
+        public string PipelineRunName { get; set; }
+        public string ImportBlobName { get; set; }
+        public TransferJobStatus Status { get; set; } = TransferJobStatus.Pending;
+    }
+
+    public enum ImportSourceType
+    {
+        AzureStorageBlob,
+        RegistryImage
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ImportWorker.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Transfer/ImportWorker.cs
@@ -1,0 +1,220 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RegistryArtifactTransfer
+{
+    public class ImportWorker
+    {
+        private readonly ImportConfiguration _importConfiguration;
+        private readonly ILogger _logger;
+        private readonly TransferClient _transferClient;
+        private readonly Registry _sourceRegistry;
+
+        public ImportWorker(
+            ImportConfiguration importConfiguration,
+            RegistryConfiguration registryConfiguration,
+            TransferClient transferClient,
+            ILogger<ImportWorker> logger)
+        {
+            if (registryConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(registryConfiguration));
+            }
+
+            _importConfiguration = importConfiguration ?? throw new ArgumentNullException(nameof(importConfiguration));
+            _transferClient = transferClient ?? throw new ArgumentNullException(nameof(transferClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            if (!string.IsNullOrWhiteSpace(importConfiguration.SourceRegistry.ResourceId))
+            {
+                var resourceId = ResourceId.Parse(importConfiguration.SourceRegistry.ResourceId);
+                _sourceRegistry = new Registry(
+                    null,
+                    resourceId.SubscriptionId,
+                    resourceId.ResourceGroupName,
+                    resourceId.ResourceName);
+            }
+            else
+            {
+                _sourceRegistry = new Registry(
+                    importConfiguration.SourceRegistry.RegistryUri,
+                    importConfiguration.SourceRegistry.UserName,
+                    importConfiguration.SourceRegistry.Password);
+            }
+        }
+
+        public async Task RunAsync(TransferReport transferReport)
+        {
+            if (!_importConfiguration.Enabled)
+            {
+                return;
+            }
+
+            //
+            // Validate importPipeline
+            if (_importConfiguration.Blobs.Count > 0)
+            {
+                var importPipeline = await _transferClient.GetImportPipelineAsync(_importConfiguration.ImportPipelineName).ConfigureAwait(false);
+                if (!importPipeline.ProvisioningState.Equals("succeeded", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new Exception($"ImportPipeline:{_importConfiguration.ImportPipelineName} is in non-success provisioning state {importPipeline.ProvisioningState}.");
+                }
+            }
+
+            var importJobs = await CreateImportJobs().ConfigureAwait(false);
+
+            await importJobs.ThrottledWhenAll(
+                async (job) => await ExecuteAsync(job).ConfigureAwait(false),
+                _importConfiguration.MaxConcurrency).ConfigureAwait(false);
+
+            foreach (var job in importJobs)
+            {
+                if (job.Status == TransferJobStatus.Succeeded)
+                {
+                    transferReport.ImportArtifacts.Succeeded.AddRange(job.Images);
+
+                    if (job.SourceType == ImportSourceType.AzureStorageBlob)
+                    {
+                        transferReport.ImportBlobs.Succeeded.Add(job.ImportBlobName);
+                    }
+                }
+                else if (job.Status == TransferJobStatus.Failed)
+                {
+                    transferReport.ImportArtifacts.Failed.AddRange(job.Images);
+
+                    if (job.SourceType == ImportSourceType.AzureStorageBlob)
+                    {
+                        transferReport.ImportBlobs.Failed.Add(job.ImportBlobName);
+                    }
+                }
+            }
+        }
+
+        private async Task<List<ImportJob>> CreateImportJobs()
+        {
+            var importJobs = new List<ImportJob>();
+            var images = new List<string>();
+
+            if (_importConfiguration.Repositories != null)
+            {
+                var artifactProvider = new ArtifactProvider(_logger);
+
+                var matchedTags = await artifactProvider.GetArtifactsAsync(
+                    _importConfiguration.SourceRegistry.RegistryUri,
+                    _importConfiguration.SourceRegistry.UserName,
+                    _importConfiguration.SourceRegistry.Password,
+                    _importConfiguration.Repositories).ConfigureAwait(false);
+
+                images.AddRange(matchedTags);
+            }
+
+            if (_importConfiguration.Tags != null)
+            {
+                images.AddRange(_importConfiguration.Tags);
+            }
+
+            _logger.LogInformation($"Total registry artifacts to import: {images.Count}");
+
+            foreach (var image in images)
+            {
+                var job = new ImportJob
+                {
+                    SourceType = ImportSourceType.RegistryImage,
+                };
+
+                job.Images.Add(image);
+                importJobs.Add(job);
+            }
+
+            var blobs = _importConfiguration.Blobs;
+            _logger.LogInformation($"Total storage blobs to import: {blobs.Count}");
+
+            if (blobs != null && blobs.Count > 0)
+            {
+                foreach (var blob in blobs)
+                {
+                    var job = new ImportJob
+                    {
+                        SourceType = ImportSourceType.AzureStorageBlob,
+                        ImportPipelineName = _importConfiguration.ImportPipelineName,
+                        PipelineRunName = Guid.NewGuid().ToString("N"),
+                        ImportBlobName = blob
+                    };
+
+                    importJobs.Add(job);
+                }
+            }
+
+            return importJobs;
+        }
+
+        private async Task ExecuteAsync(ImportJob importJob)
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(_importConfiguration.TransferTimeoutInSeconds)))
+            {
+                if (importJob.SourceType == ImportSourceType.RegistryImage)
+                {
+                    await ExecuteImportImageAsync(importJob, cts.Token).ConfigureAwait(false);
+                }
+                else if (importJob.SourceType == ImportSourceType.AzureStorageBlob)
+                {
+                    await ExecutePipelineRunAsync(importJob, cts.Token).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private async Task ExecuteImportImageAsync(ImportJob importJob, CancellationToken cancellationToken)
+        {
+            var image = importJob.Images.First();
+
+            try
+            {
+                await _transferClient.ImportImageAsync(
+                    _sourceRegistry,
+                    image,
+                    _importConfiguration.Force,
+                    cancellationToken).ConfigureAwait(false);
+
+                importJob.Status = TransferJobStatus.Succeeded;
+                _logger.LogInformation($"Sucessfully imported {image}");
+            }
+            catch (Exception e)
+            {
+                importJob.Status = TransferJobStatus.Failed;
+                _logger.LogError($"Failed to import: {image}, exception: {e}");
+            }
+        }
+
+        private async Task ExecutePipelineRunAsync(ImportJob importJob, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var importedImages = await _transferClient.ImportImagesFromStorageAsync(
+                    importJob.ImportPipelineName,
+                    importJob.PipelineRunName,
+                    importJob.ImportBlobName,
+                    cancellationToken).ConfigureAwait(false);
+
+                importJob.Status = TransferJobStatus.Succeeded;
+
+                if (importedImages != null && importedImages.Count > 0)
+                {
+                    foreach (var image in importedImages)
+                    {
+                        importJob.Images.Add(image);
+                        _logger.LogInformation($"Sucessfully imported {image}, pipelineRun:{importJob.PipelineRunName}, blob:{importJob.ImportBlobName}.");
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                importJob.Status = TransferJobStatus.Failed;
+                _logger.LogError($"Failed to import blob:{importJob.ImportBlobName}, pipelineRun:{importJob.PipelineRunName}, exception: {e}");
+            }
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Transfer/TransferClient.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Transfer/TransferClient.cs
@@ -1,0 +1,216 @@
+using Microsoft.Azure.Management.ContainerRegistry;
+using Microsoft.Azure.Management.ContainerRegistry.Models;
+using Microsoft.Azure.Management.ResourceManager.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using static RegistryArtifactTransfer.ResourceId;
+
+namespace RegistryArtifactTransfer
+{
+    public class TransferClient
+    {
+        private const string ImportModeForce = "Force";
+        private const string ImportModeNoForce = "NoForce";
+        private readonly ContainerRegistryManagementClient _registryClient;
+        private readonly RegistryConfiguration _registryConfiguration;
+
+        public TransferClient(
+            AzureEnvironmentConfiguration azureEnvironmentConfiguration,
+            IdentityConfiguration identityConfiguration,
+            RegistryConfiguration registryConfiguration)
+        {
+            _registryConfiguration = registryConfiguration ?? throw new ArgumentNullException(nameof(registryConfiguration));
+
+            var env = AzureEnvironment.FromName(azureEnvironmentConfiguration.Name);
+            if (env == null)
+            {
+                env = new AzureEnvironment
+                {
+                    Name = azureEnvironmentConfiguration.Name,
+                    AuthenticationEndpoint = azureEnvironmentConfiguration.AuthenticationEndpoint,
+                    ManagementEndpoint = azureEnvironmentConfiguration.ManagementEndpoint,
+                    ResourceManagerEndpoint = azureEnvironmentConfiguration.ResourceManagerEndpoint,
+                    GraphEndpoint = azureEnvironmentConfiguration.GraphEndpoint,
+                    KeyVaultSuffix = azureEnvironmentConfiguration.KeyVaultSuffix,
+                    StorageEndpointSuffix = azureEnvironmentConfiguration.StorageEndpointSuffix
+                };
+            }
+
+            var credential = new AzureCredentials(
+                new ServicePrincipalLoginInformation
+                {
+                    ClientId = identityConfiguration.ClientId,
+                    ClientSecret = identityConfiguration.ClientSecret
+                },
+                registryConfiguration.TenantId,
+                env);
+
+            _registryClient = new ContainerRegistryManagementClient(credential.WithDefaultSubscription(registryConfiguration.SubscriptionId));
+            _registryClient.SubscriptionId = registryConfiguration.SubscriptionId;
+        }
+
+        public async System.Threading.Tasks.Task ImportImageAsync(
+            Registry sourceRegistry,
+            string sourceImage,
+            bool force = true,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (sourceRegistry == null)
+            {
+                throw new ArgumentNullException(nameof(sourceRegistry));
+            }
+
+            var sourceResourceId = sourceRegistry.ResourceId?.ToString();
+            var sourceLoginServer = string.IsNullOrEmpty(sourceResourceId) ? sourceRegistry.LoginServer : null;
+            var importSource = new ImportSource()
+            {
+                ResourceId = sourceResourceId,
+                RegistryUri = sourceLoginServer,
+                SourceImage = sourceImage
+            };
+
+            if (!string.IsNullOrEmpty(sourceRegistry.UserName))
+            {
+                importSource.Credentials = new ImportSourceCredentials()
+                {
+                    Username = sourceRegistry.UserName,
+                    Password = sourceRegistry.Password
+                };
+            }
+
+            var importImageParameters = new ImportImageParameters()
+            {
+                Mode = force ? ImportModeForce : ImportModeNoForce,
+                Source = importSource,
+                TargetTags = new List<string>{sourceImage}
+            };
+
+            importImageParameters.Validate();
+
+            await _registryClient.Registries.ImportImageAsync(
+                _registryConfiguration.ResourceGroupName,
+                _registryConfiguration.Name,
+                importImageParameters,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        public async System.Threading.Tasks.Task<IList<string>> ImportImagesFromStorageAsync(
+            string importPipelineName,
+            string pipelineRunName,
+            string sourceBlobName,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var request = CreateImportPipelineRunRequest(importPipelineName, sourceBlobName);
+            var pipelineRun = await CreatePipelineRunAsync(pipelineRunName, request, cancellationToken).ConfigureAwait(false);
+            return pipelineRun?.Response?.ImportedArtifacts;
+        }
+
+        public async System.Threading.Tasks.Task ExportImagesToStorageAsync(
+            string exportPipelineName,
+            string pipelineRunName,
+            List<string> images,
+            string targetBlobName,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var request = CreateExportPipelineRunRequest(exportPipelineName, images, targetBlobName);
+            await CreatePipelineRunAsync(pipelineRunName, request, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async System.Threading.Tasks.Task<ExportPipeline> GetExportPipelineAsync(
+            string exportPipelineName,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await _registryClient.ExportPipelines.GetAsync(
+                _registryConfiguration.ResourceGroupName,
+                _registryConfiguration.Name,
+                exportPipelineName,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        public async System.Threading.Tasks.Task<ImportPipeline> GetImportPipelineAsync(
+            string importPipelineName,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await _registryClient.ImportPipelines.GetAsync(
+                _registryConfiguration.ResourceGroupName,
+                _registryConfiguration.Name,
+                importPipelineName,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        public async System.Threading.Tasks.Task<string> GetRegistryLoginServerAsync(
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var registry = await _registryClient.Registries.GetAsync(
+                _registryConfiguration.ResourceGroupName,
+                _registryConfiguration.Name,
+                cancellationToken).ConfigureAwait(false);
+            
+            return registry?.LoginServer;
+        }
+
+        private async System.Threading.Tasks.Task<PipelineRun> CreatePipelineRunAsync(
+            string pipelineRunName,
+            PipelineRunRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await _registryClient.PipelineRuns.CreateAsync(
+                _registryConfiguration.ResourceGroupName,
+                _registryConfiguration.Name,
+                pipelineRunName,
+                request,
+                forceUpdateTag: null,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        private PipelineRunRequest CreateImportPipelineRunRequest(
+            string importPipelineName,
+            string sourceBlobName)
+        {
+            var importPipelineResourceId = new ResourceId(
+                _registryConfiguration.SubscriptionId,
+                _registryConfiguration.ResourceGroupName,
+                _registryConfiguration.Name,
+                RegistriesARMResourceType,
+                ImportPipelineResourceType,
+                importPipelineName);
+
+            return new PipelineRunRequest
+            {
+                PipelineResourceId = importPipelineResourceId.ToString(),
+                Source = new PipelineRunSourceProperties
+                {
+                    Type = PipelineRunTargetType.AzureStorageBlob.ToString(),
+                    Name = sourceBlobName
+                }
+            };
+        }
+
+        private PipelineRunRequest CreateExportPipelineRunRequest(
+            string exportPipelineName,
+            List<string> images,
+            string targetBlobName)
+        {
+            var exportPipelineResourceId = new ResourceId(
+                _registryConfiguration.SubscriptionId,
+                _registryConfiguration.ResourceGroupName,
+                _registryConfiguration.Name,
+                RegistriesARMResourceType,
+                ExportPipelineResourceType,
+                exportPipelineName);
+
+            return new PipelineRunRequest
+            {
+                PipelineResourceId = exportPipelineResourceId.ToString(),
+                Artifacts = images,
+                Target = new PipelineRunTargetProperties
+                {
+                    Type = PipelineRunTargetType.AzureStorageBlob.ToString(),
+                    Name = targetBlobName
+                }
+            };
+        }
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/Transfer/TransferJobStatus.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/Transfer/TransferJobStatus.cs
@@ -1,0 +1,9 @@
+namespace RegistryArtifactTransfer
+{
+    public enum TransferJobStatus
+    {
+        Pending,
+        Succeeded,
+        Failed
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/TransferReport.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/TransferReport.cs
@@ -1,0 +1,11 @@
+namespace RegistryArtifactTransfer
+{
+    public class TransferReport
+    {
+        public TransferResult ImportArtifacts { get; set; } = new TransferResult();
+        public TransferResult ImportBlobs { get; set; } = new TransferResult();
+        public TransferResult ExportArtifacts { get; set; } = new TransferResult();
+        public TransferResult ExportBlobs { get; set; } = new TransferResult();
+        public TransferResult CopyBlobs { get; set; } = new TransferResult();
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/TransferResult.cs
+++ b/samples/dotnetcore/registry-artifact-transfer/src/TransferResult.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace RegistryArtifactTransfer
+{
+    public class TransferResult
+    {
+        public List<string> Succeeded { get; set; } = new List<string>();
+        public List<string> Failed { get; set; }  = new List<string>();
+    }
+}

--- a/samples/dotnetcore/registry-artifact-transfer/src/transferdefinition.json
+++ b/samples/dotnetcore/registry-artifact-transfer/src/transferdefinition.json
@@ -1,0 +1,59 @@
+﻿{
+  "AzureEnvironment": {
+    "Name": "AzureGlobalCloud"
+  },
+  "Registry": {
+    "TenantId": "myTenantId",
+    "SubscriptionId": "mySubscriptionId",
+    "ResourceGroupName": "myResourceGroupName",
+    "Name": "myRegistryName"
+  },
+  "Identity": {
+    "ClientId": "myClientId",
+    "ClientSecret": "myClientSecret"
+  },
+  "Import": {
+    "Enabled": true,
+    "Force": true,
+    "SourceRegistry": {
+      "ResourceId": "mySourceRegistryResourceId",
+      "RegistryUri": "mysourceregistry.azurecr.io",
+      "UserName": "clientId-or-adminUser",
+      "Password": "clientSecret-or-adminPassword"
+    },
+    "Repositories": [
+      "sourceRepo",
+      "sourceRepoPrefix*"
+    ],
+    "Tags": [
+      "sourceRepo1:tag1",
+      "sourceRepo2:tag2"
+    ],
+    "ImportPipelineName": "myImportPipelineName",
+    "Blobs": [
+      "exportedBlob1",
+      "exportedBlob2",
+      "exportedBlob3"
+    ]
+  },
+  "Export": {
+    "Enabled": true,
+    "ExportPipelineName": "myExportPipelineName",
+    "MaxArtifactCountPerBlob": 50,
+    "BlobNamePrefix": "artifacts",
+    "IncludeImportedArtifacts": true,
+    "Repositories": [
+      "targetRepo",
+      "targetRepoPrefix*"
+    ],
+    "Tags": [
+      "targetRepo1:tag1",
+      "targetRepo2:tag2"
+    ],
+    "CopyBlobs": {
+      "Enabled": true,
+      "SourceSasToken": "sourceBlobContainerSasToken",
+      "DestContainerSasUri": "destinationBlobContainerSasUri"
+    }
+  }
+}


### PR DESCRIPTION
Publish Registry Artifact Transfer Tool as another sample for the ACR transfer feature. The tool supports streamline artifact transfer from one registry to another via both ACR image import and ACR transfer.