### PR TITLE
Remove dupe of ACR Links list

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,4 +18,4 @@ This repo contains [issues](https://github.com/Azure/acr/issues), [samples](./do
 
 ## Links
 
-See [ACR Links](./README.md/#links)
+See [ACR Links](../README.md/#links)

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@ title: Overview
 type: post
 ---
 
-# Overview
+## Overview
 
 This repo contains [issues](https://github.com/Azure/acr/issues), [samples](./docs), [troubleshooting tips](./docs/Troubleshooting%20Guide.md), and a collection of links for Azure Container Registry.
 
@@ -16,51 +16,6 @@ This repo contains [issues](https://github.com/Azure/acr/issues), [samples](./do
 * [Docker Tagging Best Practices](https://stevelasker.blog/2018/03/01/docker-tagging-best-practices-for-tagging-and-versioning-docker-images/)
 * [Deploying Docker Images to Azure Container Instances](https://stevelasker.blog/2017/07/28/deploying-docker-images-from-the-azure-container-registry-to-azure-container-instances/)
 
-
 ## Links
-| Title | Link |
-| - | - |
-| [Service Overview](https://aka.ms/acr) | https://aka.ms/acr |
-| [Links](https://aka.ms/acr/links) | https://aka.ms/acr/links | 
-| [Docs](https://aka.ms/acr/docs) | https://aka.ms/acr/docs |
-| [CLI Docs](https://aka.ms/acr/docs/cli) | https://aka.ms/acr/docs/cli |
-| [Pricing](https://aka.ms/acr/pricing) | https://aka.ms/acr/pricing |
-| [Tiers](https://aka.ms/acr/tiers) | https://aka.ms/acr/tiers |
-| [Authentication](https://aka.ms/acr/authentication) | https://aka.ms/acr/authentication |
-| [Authorization Roles](https://aka.ms/acr/authentication/roles) | https://aka.ms/acr/authentication/roles |
-| [Health Check CLI](https://aka.ms/acr/health-check) | https://aka.ms/acr/health-check |
-| [Tasks](https://aka.ms/acr/tasks) | https://aka.ms/acr/tasks |
-| [Task Scheduling](https://aka.ms/acr/tasks/scheduling) | https://aka.ms/acr/tasks/scheduling |
-| [Task Timer Cron Expressions](https://aka.ms/acr/tasks/cron) | https://aka.ms/acr/tasks/cron |
-| [Helm Chart Repos](https://aka.ms/acr/helm-repos) | https://aka.ms/acr/helm-repos |
-| [Geo-replication](https://aka.ms/acr/geo-replication) | https://aka.ms/acr/geo-replication |
-| [VNet & Firewall Rules](https://aka.ms/acr/vnet) | https://aka.ms/acr/vnet |
-| [Content Trust / Signing](https://aka.ms/acr/content-trust) | https://aka.ms/acr/content-trust |
-| [Importing Containers](https://aka.ms/acr/import) | https://aka.ms/acr/import |
-| [Quarantine Pattern](https://aka.ms/acr/quarantine) | https://aka.ms/acr/quarantine |
-| [Tag Locking](https://aka.ms/acr/tag-locking) | https://aka.ms/acr/tag-locking |
-| [OCI Artifacts](https://aka.ms/acr/artifacts) | https://aka.ms/acr/artifacts |
-| [FAQ](https://aka.ms/acr/faq) | https://aka.ms/acr/faq |
-| [Roadmap](https://aka.ms/acr/roadmap) | https://aka.ms/acr/roadmap |
-| [Presentations](https://aka.ms/acr/presentations) | https://aka.ms/acr/presentations |
-| [Jobs](https://aka.ms/acr/jobs) | https://aka.ms/acr/jobs |
-| Twitter | #AzureContainerRegistry |
 
-## Providing feedback
-| Title | Link |
-|-|-|
-| [**Stack overflow** for community support](https://aka.ms/acr/stack-overflow) | https://aka.ms/acr/stack-overflow |
-| [**User Voice** for feature requests](https://aka.ms/acr/uservoice) | https://aka.ms/acr/uservoice |
-| [**Github** for logging issues](https://aka.ms/acr/issues) | https://aka.ms/acr/issues |
-| [**Slack** for collaboration](https://aka.ms/acr/slack) | https://aka.ms/acr/slack |
-| [**Create a ticket** for general support](https://aka.ms/acr/support/create-ticket) | https://aka.ms/acr/support/create-ticket |
-
-
-## API and SDK reference
-
-* [REST API Reference](https://docs.microsoft.com/rest/api/containerregistry/)
-* [Swagger Specification](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/stable/2017-10-01/containerregistry.json)
-* [SDK for Python](https://pypi.python.org/pypi/azure-mgmt-containerregistry)
-* [SDK for Python-Source](https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-containerregistry)
-* [SDK for .NET](https://www.nuget.org/packages/Microsoft.Azure.Management.ContainerRegistry)
-* [SDK for .NET-Source](https://github.com/Azure/azure-sdk-for-net/tree/master/src/SDKs/ContainerRegistry)
+See [ACR Links](./README.md/#links)


### PR DESCRIPTION
Remove dupe of ACR Links list, re-routing to the Links in the root README.md