### PR TITLE
docs: add AKS Engine and capz header values

### DIFF
--- a/docs/http-headers.md
+++ b/docs/http-headers.md
@@ -46,20 +46,22 @@ The values we ask ACR partners to use when populating the `X-Meta-Source-Client`
 | On Premise                | `on-prem/                               |
 
 
-| Service name              | Header                                  |
-| ------------------------- | --------------------------------------- |
-| App Service - Logic Apps  | `azure/app-service/logic-apps`          |
-| App Service - Web Apps    | `azure/app-service/web-apps`            |
-| Azure Container Builder   | `azure/acb`                             |
-| Azure Container Instance  | `azure/aci`                             |
-| Azure Container Service   | `azure/acs`                             |
-| Azure Kubernetes Service  | `azure/aks`                             |
-| Batch                     | `azure/batch`                           |
-| Cloud Console             | `azure/cloud-console`                   |
-| Functions                 | `azure/functions`                       |
-| HDInsight                 | `azure/hdinsight`                       |
-| Internet of Things - Hub  | `azure/iot/hub`                         |
-| Jenkins                   | `azure/jenkins`                         |
-| Machine Learning          | `azure/ml`                              |
-| Service Fabric            | `azure/service-fabric`                  |
-| VSTS                      | `azure/vsts`                            |
+| Service or Orchestrator name   | Header                                  |
+| ------------------------------ | --------------------------------------- |
+| App Service - Logic Apps       | `azure/app-service/logic-apps`          |
+| App Service - Web Apps         | `azure/app-service/web-apps`            |
+| Azure Container Builder        | `azure/acb`                             |
+| Azure Container Instance       | `azure/aci`                             |
+| Azure Container Service        | `azure/acs`                             |
+| Azure Kubernetes Service       | `azure/aks`                             |
+| AKS Engine (Kubernetes)        | `azure/aks-engine`                      |
+| Cluster API Azure (Kubernetes) | `azure/capz`                            |
+| Batch                          | `azure/batch`                           |
+| Cloud Console                  | `azure/cloud-console`                   |
+| Functions                      | `azure/functions`                       |
+| HDInsight                      | `azure/hdinsight`                       |
+| Internet of Things - Hub       | `azure/iot/hub`                         |
+| Jenkins                        | `azure/jenkins`                         |
+| Machine Learning               | `azure/ml`                              |
+| Service Fabric                 | `azure/service-fabric`                  |
+| VSTS                           | `azure/vsts`                            |


### PR DESCRIPTION
This PR adds header values for the AKS Engine and Cluster API (capz) Kubernetes open source projects.

- AKS Engine: https://github.com/Azure/aks-engine
- capz: https://github.com/kubernetes-sigs/cluster-api-provider-azure

Also modified the table heading to "Service or Orchestrator name" to clarify that not all header names listed are services (neither AKS Engine nor capz is an Azure service!)