### PR TITLE
Update URLs in custom domain deprecated documentation

### DIFF
--- a/docs/custom-domain/deprecated/docker-vm-deploy/azuredeploy.json
+++ b/docs/custom-domain/deprecated/docker-vm-deploy/azuredeploy.json
@@ -259,7 +259,7 @@
         "typeHandlerVersion": "2.0",
         "autoUpgradeMinorVersion": true,
         "settings": {
-          "fileUris": ["https://raw.githubusercontent.com/Azure/acr/master/docs/custom-domain/docker-vm-deploy/deploy-nginx-docker.sh"]
+          "fileUris": ["https://raw.githubusercontent.com/Azure/acr/main/docs/custom-domain/deprecated/docker-vm-deploy/deploy-nginx-docker.sh"]
         },
         "protectedSettings": {
           "commandToExecute": "[concat('./deploy-nginx-docker.sh ', parameters('certThumbPrint'), ' ', parameters('backendRegistry'), ' ', parameters('dnsFrontEnd'), ' \"', parameters('caCertUrl'), '\"')]"

--- a/docs/custom-domain/deprecated/docker-vm-deploy/deploy-nginx-docker.sh
+++ b/docs/custom-domain/deprecated/docker-vm-deploy/deploy-nginx-docker.sh
@@ -6,22 +6,22 @@ export BACKEND_HOST=$2
 export FRONTEND_HOST=$3
 CA_CERT_URL=$4
 
-SOURCE_ROOT="https://raw.githubusercontent.com/Azure/acr/master"
+SOURCE_ROOT="https://raw.githubusercontent.com/Azure/acr/main"
 
-curl "$SOURCE_ROOT/docs/custom-domain/docker-vm-deploy/setup-certs.sh" -o  setup-certs.sh
+curl "$SOURCE_ROOT/docs/custom-domain/deprecated/docker-vm-deploy/setup-certs.sh" -o  setup-certs.sh
 chmod +x ./setup-certs.sh
 . ./setup-certs.sh $CERT_FINGERPRINT $CA_CERT_URL
 
 export CONTAINER_CERT_LOCATION="/etc/nginx/ssl/cert.crt"
 export CONTAINER_PRV_LOCATION="/etc/nginx/ssl/private.key"
 
-curl "$SOURCE_ROOT/docs/custom-domain/docker-vm-deploy/docker-compose.yml.template" -o  docker-compose.yml.template
+curl "$SOURCE_ROOT/docs/custom-domain/deprecated/docker-vm-deploy/docker-compose.yml.template" -o  docker-compose.yml.template
 sudo -E envsubst '$CERT_LOCATION$PRV_LOCATION$CONTAINER_CERT_LOCATION$CONTAINER_PRV_LOCATION' < docker-compose.yml.template > docker-compose.yml
 
 export CERT_LOCATION=$CONTAINER_CERT_LOCATION
 export PRV_LOCATION=$CONTAINER_PRV_LOCATION
 
-curl "$SOURCE_ROOT/docs/custom-domain/docker-vm-deploy/nginx.conf.template" -o  nginx.conf.template
+curl "$SOURCE_ROOT/docs/custom-domain/deprecated/docker-vm-deploy/nginx.conf.template" -o  nginx.conf.template
 sudo -E envsubst '$FRONTEND_HOST$BACKEND_HOST$CERT_LOCATION$PRV_LOCATION' < nginx.conf.template > nginx.conf
 
 ## Docker installation extension installs docker in the background


### PR DESCRIPTION
Documentation have been moved in 'deprecated' folder and some links have been broken.