### PR TITLE
Remove registry deployment from export pipeline

### DIFF
--- a/docs/image-transfer/ExportPipelines/azuredeploy.json
+++ b/docs/image-transfer/ExportPipelines/azuredeploy.json
@@ -75,31 +75,10 @@
   },
   "resources": [
     {
-      "type": "Microsoft.ContainerRegistry/registries",
-      "apiVersion": "2019-12-01-preview",
-      "name": "[parameters('registryName')]",
-      "location": "[parameters('location')]",
-      "comments": "Container registry for storing docker images",
-      "tags": {
-        "displayName": "Container Registry",
-        "container.registry": "[parameters('registryName')]"
-      },
-      "sku": {
-        "name": "Premium",
-        "tier": "Premium"
-      },
-      "properties": {
-        "adminUserEnabled": false
-      }
-    },
-    {
       "type": "Microsoft.ContainerRegistry/registries/exportPipelines/",
       "name": "[concat(parameters('registryName'), '/', parameters('exportPipelineName'))]",
       "location": "[parameters('location')]",
       "apiVersion": "2019-12-01-preview",
-      "dependsOn": [
-        "[resourceId('Microsoft.ContainerRegistry/registries', parameters('registryName'))]"
-      ],
       "identity": "[if(not(empty(parameters('userAssignedIdentity'))), variables('userIdentity'), variables('systemIdentity'))]",
       "properties": {
         "target": {


### PR DESCRIPTION
Remove container registry from export pipeline template to avoid scenarios where customers accidentally overwrite registry properties when deploying an export pipeline. 