### PR TITLE
Update bootstrap.yaml

### DIFF
--- a/docs/tasks/buildx/bootstrap.yaml
+++ b/docs/tasks/buildx/bootstrap.yaml
@@ -1,7 +1,7 @@
 version: v1.0.0
 steps:
   # Build buildx from source using the built-in buildkit
-  - cmd: docker build -t binaries git://github.com/docker/buildx
+  - cmd: docker build -t binaries https://github.com/docker/buildx.git
     env: [ "DOCKER_BUILDKIT=1" ]
   # Create a new Dockerfile to set up the entry point for buildx
   - cmd: |


### PR DESCRIPTION
Fix buildx repo url. See: https://github.blog/2021-09-01-improving-git-protocol-security-github/

This was the error I was getting when using the provided `bootstrap.yaml`:

```console
❯ az acr run --registry XXX -f bootstrap.yaml /dev/null
Queued a run with ID: dc11
Waiting for an agent...
2022/04/06 15:12:18 Alias support enabled for version >= 1.1.0, please see https://aka.ms/acr/tasks/task-aliases for more information.
2022/04/06 15:12:18 Creating Docker network: acb_default_network, driver: 'bridge'
2022/04/06 15:12:18 Successfully set up Docker network: acb_default_network
2022/04/06 15:12:18 Setting up Docker configuration...
2022/04/06 15:12:19 Successfully set up Docker configuration
2022/04/06 15:12:19 Logging in to registry: XXX.azurecr.io
2022/04/06 15:12:20 Successfully logged into XXX.azurecr.io
2022/04/06 15:12:20 Executing step ID: acb_step_0. Timeout(sec): 600, Working directory: '', Network: 'acb_default_network'
2022/04/06 15:12:20 Launching container with name: acb_step_0
#1 [internal] load git source git://github.com/docker/buildx
#1 sha256:be0b108b985d6d23ec37495ba62242abd838bc40414caed47d95872ce41e3638
#1 0.073 Initialized empty Git repository in /var/lib/docker/overlay2/jefskzs20mo3wa8nnw77qk9ca/diff/
#1 0.315 fatal: remote error: 
#1 0.315   The unauthenticated git protocol on port 9418 is no longer supported.
#1 0.315 Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
#1 ERROR: failed to fetch remote git://github.com/docker/buildx: exit status 128
------
 > [internal] load git source git://github.com/docker/buildx:
------
failed to solve with frontend dockerfile.v0: failed to read dockerfile: failed to load cache key: failed to fetch remote git://github.com/docker/buildx: exit status 128
2022/04/06 15:12:21 Container failed during run: acb_step_0. No retries remaining.
failed to run step ID: acb_step_0: exit status 1

Run ID: dc11 failed after 5s. Error: failed during run, err: exit status 1
Run failed
```