### PR TITLE
Add SAN extension to open-ssl docs

### DIFF
--- a/docs/custom-domain/README.md
+++ b/docs/custom-domain/README.md
@@ -53,7 +53,8 @@ XXXXXX-02
     openssl req -nodes -x509 -newkey rsa:4096 \
       -keyout container-registry.contoso.com.key.pem \
       -out container-registry.contoso.com.cert.pem -days 365 \
-      -subj '/CN=container-registry.contoso.com/O=Contoso./C=US'
+      -subj '/CN=container-registry.contoso.com/O=Contoso./C=US' \ 
+      -addext "subjectAltName = DNS:container-registry.contoso.com"
     ```
   - Create a single file containing both the public certificate (or certificates, in the case of a certificate bundle) and private key
     ```shell


### PR DESCRIPTION
Following the docs, you get an error when accessing the new custom domain name with the openssl generated certificate.
```
Get "https://container-registry.contoso.com/v2/": x509: certificate relies on legacy Common Name field, use SANs instead
```

Need to specify the SAN extension with DNS to overcome this:
1. [Source 1](https://frasertweedale.github.io/blog-redhat/posts/2017-07-11-cn-deprecation.html)
2. [Source 2](https://stackoverflow.com/questions/64814173/how-do-i-use-sans-with-openssl-instead-of-common-name)
3. [Source 3](https://forums.docker.com/t/installed-docker-version-20-10-8-unable-to-docker-pull-because-of-error-x509-certificate-relies-on-legacy-common-name-field/116326)