### PR TITLE
Continous Patching Preview Documentation

### DIFF
--- a/docs/preview/continuous-patching/README.md
+++ b/docs/preview/continuous-patching/README.md
@@ -261,7 +261,7 @@ Once a workflow is successfully deleted, the repository "csscpolicies/patchpolic
 
 To list the most recently executed Continuous Patching tasks, the following List command is available:
 ```sh
-az acr supply-chain workflow list -r <registryname> -g <resourcegroup> [–-run-status <failed || successful || running>]
+az acr supply-chain workflow list -r <registryname> -g <resourcegroup> [–-run-status <failed || successful || running>] -t continuouspatchv1
 ```
 
 A successful result will return the following information:


### PR DESCRIPTION
List Running Tasks doesn't have required argument `--type -t` in example.

```sh
az acr supply-chain workflow list -r <registryname> -g <resourcegroup> [–-run-status <failed || successful || running>]
```

The correct command should be:
```sh
az acr supply-chain workflow list -r <registryname> -g <resourcegroup> [–-run-status <failed || successful || running>] -t continuouspatchv1
```