### PR TITLE
Update patching docs to use hyphen instead of en dash

### DIFF
--- a/docs/preview/continuous-patching/README.md
+++ b/docs/preview/continuous-patching/README.md
@@ -128,7 +128,7 @@ az acr supply-chain workflow create -r <registryname> -g <resourcegroupname> -t 
 ```
 Example Command: 
 ```sh
-az acr supply-chain workflow create -r myRegistry -g myResourceGroup -t continuouspatchv1 -–config ./continuouspatching.json --schedule 1d –-dry-run   
+az acr supply-chain workflow create -r myRegistry -g myResourceGroup -t continuouspatchv1 --config ./continuouspatching.json --schedule 1d --dry-run   
 ```
 
 The ```--dry-run``` flag will output all specified artifacts by the JSON file configuration. Customers can verify that the right artifacts are selected. With the sample ubuntu configuration above, the following results should be displayed as output. 
@@ -157,12 +157,12 @@ The ```--schedule``` parameter follows a fixed-day multiplier starting from day 
 
 Command Schema:
 ```sh
-az acr supply-chain workflow create -r <registryname> -g <resourcegroupname> -t continuouspatchv1 -–config <JSONfilename> --schedule <number of days> --run-immediately
+az acr supply-chain workflow create -r <registryname> -g <resourcegroupname> -t continuouspatchv1 --config <JSONfilename> --schedule <number of days> --run-immediately
 ```
 
 Example Command: 
 ```sh
-az acr supply-chain workflow create -r myRegistry -g myResourceGroup -t continuouspatchv1 -–config ./continuouspatching.json --schedule 1d --run-immediately
+az acr supply-chain workflow create -r myRegistry -g myResourceGroup -t continuouspatchv1 --config ./continuouspatching.json --schedule 1d --run-immediately
 ```
 
 Upon a successful command (whether or not you include ```--run-immediately```), you will see:
@@ -185,9 +185,9 @@ Next, click on "Tasks” under "Services”. You should see 3 new tasks, named t
 
 ![PortalTasks](./media/portal_tasks1.png)
 
-- cssc-trigger-workflow – this task scans the configuration file and calls the scan task on each respective image.    
-- cssc-scan-image – this task scans the image for operating system vulnerabilities. This task will only trigger the patching task only if (1) operating system vulnerabilities were found, and (2) the image is not considered End of Service Life (EOSL). For more information on EOSL, please consult [Preview Limitations](#preview-limitations).
-- cssc-patch-image – this task patches the image.
+- cssc-trigger-workflow - this task scans the configuration file and calls the scan task on each respective image.    
+- cssc-scan-image - this task scans the image for operating system vulnerabilities. This task will only trigger the patching task only if (1) operating system vulnerabilities were found, and (2) the image is not considered End of Service Life (EOSL). For more information on EOSL, please consult [Preview Limitations](#preview-limitations).
+- cssc-patch-image - this task patches the image.
 These tasks work in conjunction to execute your continuous patching workflow.
 
 You can also click on "Runs” within the "Tasks” view to see specific task runs. Here you can view status information on whether the task succeeded or failed, along with viewing a debug log. 
@@ -248,7 +248,7 @@ az acr supply-chain workflow delete -r <registry> -g <resourceGroup> -t continuo
 ```
 Example Command 
 ```sh
-az acr supply-chain workflow delete -r myregistry -g myresourcegroup –t continuouspatchv1
+az acr supply-chain workflow delete -r myregistry -g myresourcegroup -t continuouspatchv1
 ```
 Help command to see all required/optional flags
 ```sh
@@ -261,7 +261,7 @@ Once a workflow is successfully deleted, the repository "csscpolicies/patchpolic
 
 To list the most recently executed Continuous Patching tasks, the following List command is available:
 ```sh
-az acr supply-chain workflow list -r <registryname> -g <resourcegroup> [–-run-status <failed || successful || running>] -t continuouspatchv1
+az acr supply-chain workflow list -r <registryname> -g <resourcegroup> [--run-status <failed || successful || running>] -t continuouspatchv1
 ```
 
 A successful result will return the following information:
@@ -325,7 +325,7 @@ If the logs aren't sufficient, or an issue is persistent, or for any feedback, p
 **Possible CLI Outputs for 'List' Command**
 
 ```sh
-az acr supply-chain workflow list -r <registryname> -g <resourcegroup> [–-run-status <Failed || Queued || Running || Skipped || Succeeded || Unknown>]
+az acr supply-chain workflow list -r <registryname> -g <resourcegroup> [--run-status <Failed || Queued || Running || Skipped || Succeeded || Unknown>]
 ```
 
 If scan and patch are successful


### PR DESCRIPTION
ACR Continuous Patching Docs (https://aka.ms/acr/patching) are currently using en dashes throughout the docs.

![image](https://github.com/user-attachments/assets/21bdba05-2dc3-42ed-9770-6867e1de854f)

This causes commands using the en dashes to fail and leads to CLI arguments not being recognized.

![image](https://github.com/user-attachments/assets/a87d40a6-4c8f-4c2f-9226-618981c82bd2)
