### PR TITLE
fix: fix stale bot error by adding permissions to the bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The stale bot ran failed due to lacking of permissions to write to the issues & PRs. See route cause and error logs: https://github.com/Azure/acr/actions/runs/16765846285/job/47470627829#step:2:374
<img width="799" height="862" alt="image" src="https://github.com/user-attachments/assets/4aedc39d-d41f-4ad0-ad82-2e6e8b741861" />
