### PR TITLE
Add Managed Identity storage access mode support to ACR Transfer templates

### DIFF
--- a/docs/image-transfer/ExportPipelines/azuredeploy.json
+++ b/docs/image-transfer/ExportPipelines/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "location": {
@@ -56,6 +56,17 @@
         "description": "The list of all options configured for the pipeline."
       },
       "defaultValue": []
+    },
+    "storageAccessMode": {
+      "type": "string",
+      "defaultValue": "SasToken",
+      "allowedValues": [
+        "SasToken",
+        "ManagedIdentity"
+      ],
+      "metadata": {
+        "description": "The storage access mode for the export pipeline. Use 'SasToken' to authenticate via a SAS token stored in Key Vault, or 'ManagedIdentity' to authenticate directly using an Entra managed identity."
+      }
     }
   },
   "variables": {
@@ -78,21 +89,23 @@
       "type": "Microsoft.ContainerRegistry/registries/exportPipelines/",
       "name": "[concat(parameters('registryName'), '/', parameters('exportPipelineName'))]",
       "location": "[parameters('location')]",
-      "apiVersion": "2019-12-01-preview",
+      "apiVersion": "2025-06-01-preview",
       "identity": "[if(not(empty(parameters('userAssignedIdentity'))), variables('userIdentity'), variables('systemIdentity'))]",
       "properties": {
         "target": {
           "type": "[variables('targetType')]",
           "uri": "[parameters('targetUri')]",
-          "keyVaultUri": "[concat(reference(resourceId('Microsoft.KeyVault/vaults', parameters('KeyVaultName')), '2019-09-01').vaultUri, 'secrets/', parameters('sasTokenSecretName'))]"
+          "keyVaultUri": "[concat(reference(resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), '2023-07-01').vaultUri, 'secrets/', parameters('sasTokenSecretName'))]",
+          "storageAccessMode": "[parameters('storageAccessMode')]"
         },
         "options": "[parameters('options')]"
       }
     },
     {
+      "condition": "[equals(parameters('storageAccessMode'), 'SasToken')]",
       "type": "Microsoft.KeyVault/vaults/accessPolicies",
       "name": "[concat(parameters('keyVaultName'), '/add')]",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2023-07-01",
       "dependsOn": [
         "[resourceId('Microsoft.ContainerRegistry/registries/exportPipelines', parameters('registryName'), parameters('exportPipelineName'))]"
       ],
@@ -100,7 +113,7 @@
         "accessPolicies": [
           {
             "tenantId": "[subscription().tenantId]",
-            "objectId": "[if(not(empty(parameters('userAssignedIdentity'))), reference(parameters('userAssignedIdentity'), '2018-11-30').principalId, reference(resourceId('Microsoft.ContainerRegistry/registries/exportPipelines', parameters('registryName'), parameters('exportPipelineName')), '2019-12-01-preview', 'Full').identity.principalId)]",
+            "objectId": "[if(not(empty(parameters('userAssignedIdentity'))), reference(parameters('userAssignedIdentity'), '2023-01-31').principalId, reference(resourceId('Microsoft.ContainerRegistry/registries/exportPipelines', parameters('registryName'), parameters('exportPipelineName')), '2025-06-01-preview', 'Full').identity.principalId)]",
             "permissions": {
               "secrets": "[variables('keyVaultSecretsPermissions')]"
             }

--- a/docs/image-transfer/ExportPipelines/azuredeploy.parameters.json
+++ b/docs/image-transfer/ExportPipelines/azuredeploy.parameters.json
@@ -22,6 +22,9 @@
         "OverwriteBlobs",
         "ContinueOnErrors"
       ]
+    },
+    "storageAccessMode": {
+      "value": "SasToken"
     }
   }
 }

--- a/docs/image-transfer/ImportPipelines/azuredeploy.json
+++ b/docs/image-transfer/ImportPipelines/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "location": {
@@ -67,6 +67,17 @@
         "description": "The list of all options configured for the pipeline."
       },
       "defaultValue": []
+    },
+    "storageAccessMode": {
+      "type": "string",
+      "defaultValue": "SasToken",
+      "allowedValues": [
+        "SasToken",
+        "ManagedIdentity"
+      ],
+      "metadata": {
+        "description": "The storage access mode for the import pipeline. Use 'SasToken' to authenticate via a SAS token stored in Key Vault, or 'ManagedIdentity' to authenticate directly using an Entra managed identity."
+      }
     }
   },
   "variables": {
@@ -89,13 +100,14 @@
       "type": "Microsoft.ContainerRegistry/registries/importPipelines/",
       "name": "[concat(parameters('registryName'), '/', parameters('importPipelineName'))]",
       "location": "[parameters('location')]",
-      "apiVersion": "2019-12-01-preview",
+      "apiVersion": "2025-06-01-preview",
       "identity": "[if(not(empty(parameters('userAssignedIdentity'))), variables('userIdentity'), variables('systemIdentity'))]",
       "properties": {
         "source": {
           "type": "[variables('sourceType')]",
           "uri": "[parameters('sourceUri')]",
-          "keyVaultUri": "[concat(reference(resourceId('Microsoft.KeyVault/vaults', parameters('KeyVaultName')), '2019-09-01').vaultUri, 'secrets/', parameters('sasTokenSecretName'))]"
+          "keyVaultUri": "[concat(reference(resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), '2023-07-01').vaultUri, 'secrets/', parameters('sasTokenSecretName'))]",
+          "storageAccessMode": "[parameters('storageAccessMode')]"
         },
         "trigger": {
           "sourceTrigger": {
@@ -106,9 +118,10 @@
       }
     },
     {
+      "condition": "[equals(parameters('storageAccessMode'), 'SasToken')]",
       "type": "Microsoft.KeyVault/vaults/accessPolicies",
       "name": "[concat(parameters('keyVaultName'), '/add')]",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2023-07-01",
       "dependsOn": [
         "[resourceId('Microsoft.ContainerRegistry/registries/importPipelines', parameters('registryName'), parameters('importPipelineName'))]"
       ],
@@ -116,7 +129,7 @@
         "accessPolicies": [
           {
             "tenantId": "[subscription().tenantId]",
-            "objectId": "[if(not(empty(parameters('userAssignedIdentity'))), reference(parameters('userAssignedIdentity'), '2018-11-30').principalId, reference(resourceId('Microsoft.ContainerRegistry/registries/importPipelines', parameters('registryName'), parameters('importPipelineName')), '2019-12-01-preview', 'Full').identity.principalId)]",
+            "objectId": "[if(not(empty(parameters('userAssignedIdentity'))), reference(parameters('userAssignedIdentity'), '2023-01-31').principalId, reference(resourceId('Microsoft.ContainerRegistry/registries/importPipelines', parameters('registryName'), parameters('importPipelineName')), '2025-06-01-preview', 'Full').identity.principalId)]",
             "permissions": {
               "secrets": "[variables('keyVaultSecretsPermissions')]"
             }

--- a/docs/image-transfer/ImportPipelines/azuredeploy.parameters.json
+++ b/docs/image-transfer/ImportPipelines/azuredeploy.parameters.json
@@ -23,6 +23,9 @@
         "DeleteSourceBlobOnSuccess",
         "ContinueOnErrors"
       ]
+    },
+    "storageAccessMode": {
+      "value": "SasToken"
     }
   }
 }

--- a/docs/image-transfer/PipelineRun/PipelineRun-Export/azuredeploy.json
+++ b/docs/image-transfer/PipelineRun/PipelineRun-Export/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "location": {
@@ -75,7 +75,7 @@
       "type": "Microsoft.ContainerRegistry/registries/pipelineRuns/",
       "name": "[concat(parameters('registryName'), '/', parameters('pipelineRunName'))]",
       "location": "[parameters('location')]",
-      "apiVersion": "2019-12-01-preview",
+      "apiVersion": "2025-06-01-preview",
       "properties": {
         "request": {
           "pipelineResourceId": "[parameters('pipelineResourceId')]",

--- a/docs/image-transfer/PipelineRun/PipelineRun-Import/azuredeploy.json
+++ b/docs/image-transfer/PipelineRun/PipelineRun-Import/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "location": {
@@ -75,7 +75,7 @@
       "type": "Microsoft.ContainerRegistry/registries/pipelineRuns/",
       "name": "[concat(parameters('registryName'), '/', parameters('pipelineRunName'))]",
       "location": "[parameters('location')]",
-      "apiVersion": "2019-12-01-preview",
+      "apiVersion": "2025-06-01-preview",
       "properties": {
         "request": {
           "pipelineResourceId": "[parameters('pipelineResourceId')]",

--- a/docs/image-transfer/README.md
+++ b/docs/image-transfer/README.md
@@ -1,1 +1,35 @@
-See public docs: https://aka.ms/acr/transfer.
+# ACR Transfer - Sample ARM Templates
+
+This directory contains Azure Resource Manager (ARM) templates for ACR Transfer, a feature for transferring container images and OCI artifacts between Azure Container Registries in disconnected environments.
+
+## Templates
+
+| Directory | Description |
+|-----------|-------------|
+| [ExportPipelines](./ExportPipelines) | Creates an ExportPipeline resource for exporting artifacts from a container registry to a storage account blob container. |
+| [ImportPipelines](./ImportPipelines) | Creates an ImportPipeline resource for importing artifacts from a storage account blob container into a container registry. |
+| [PipelineRun/PipelineRun-Export](./PipelineRun/PipelineRun-Export) | Creates a PipelineRun resource to trigger an export pipeline. |
+| [PipelineRun/PipelineRun-Import](./PipelineRun/PipelineRun-Import) | Creates a PipelineRun resource to trigger an import pipeline. |
+
+## Documentation
+
+For complete documentation including prerequisites, setup instructions, and usage examples, see:
+
+**[ACR Transfer Documentation](https://aka.ms/acr/transfer)**
+
+The documentation covers:
+
+- What is ACR Transfer and how it works
+- Storage access modes (SAS Token vs Managed Identity)
+- Prerequisites and setup
+- Step-by-step guides for Azure CLI and ARM templates
+- Troubleshooting
+
+## Quick Start
+
+These templates require:
+
+- Azure Container Registry Premium tier
+- Storage accounts with blob containers
+- API version `2025-06-01-preview` or later
+- For detailed prerequisites and instructions, refer to the [official documentation](https://aka.ms/acr/transfer)


### PR DESCRIPTION
## Summary
This PR adds support for Managed Identity authentication mode to ACR Transfer ARM templates, enabling pipelines to authenticate directly to storage accounts using Microsoft Entra managed identities without requiring Key Vault or SAS tokens.

## Changes

### Template Updates
- **ExportPipeline & ImportPipeline templates**: Add `storageAccessMode` parameter supporting both `SasToken` (default) and `ManagedIdentity` modes
- **Conditional Key Vault policies**: Only create Key Vault access policies when using `SasToken` mode; skip entirely for `ManagedIdentity` mode
- **API version upgrade**: Update all pipeline resources (Export, Import, PipelineRun) to API version `2025-06-01-preview`
- **Parameter descriptions**: Clarify mode-specific requirements for `keyVaultName` and `sasTokenSecretName` parameters

### Documentation
- **README simplification**: Streamline README to reference official documentation at https://aka.ms/acr/transfer as single source of truth, preventing documentation drift
- **Template parameters**: Update parameter files with `storageAccessMode: "SasToken"` default value

## Authentication Modes

**SasToken Mode (default)**:
- Pipeline's managed identity reads SAS token from Key Vault
- SAS token used to authenticate to storage account
- Requires: Key Vault + SAS token secret + access policy

**ManagedIdentity Mode**:
- Pipeline's managed identity authenticates directly to storage account via RBAC
- Requires: `Storage Blob Data Contributor` role assignment on storage account
- No Key Vault or SAS token needed

## Related Changes
Documentation updates for this feature are tracked in https://github.com/MicrosoftDocs/azure-management-docs-pr/pull/2172