### PR TITLE
Add Microsoft Defender for Cloud header values; clarify analytics-only usage

### DIFF
--- a/docs/http-headers.md
+++ b/docs/http-headers.md
@@ -66,3 +66,17 @@ The values we ask ACR partners to use when populating the `X-Meta-Source-Client`
 | VSTS                           | `azure/vsts`                              |
 | ACR Tasks                      | `azure/acr/tasks`                         |
 | ACR Connected Registry         | `azure/acr/connected-registry/instance-1` |
+| Microsoft Defender for Cloud - ACR scanner that pulls images for vulnerability assessment | `azure/mdc/scanner-svc-image-puller`      |
+| Microsoft Defender for Cloud - ACR scanner for registry discovery and metadata            | `azure/mdc/scanner-svc-image-discovery`   |
+| Microsoft Defender for Cloud - Azure DevOps CLI scanner that pulls images                 | `azure/mdc/scanner-ado-cli-image-puller`  |
+
+## How ACR uses this header
+
+The `X-Meta-Source-Client` header is a client-supplied, unauthenticated, and untrusted value. Both Microsoft and non-Microsoft clients can set or modify it freely, and ACR does not validate it during requests. ACR uses this header **only** for telemetry — traffic analysis, aggregation, and attribution of request sources to understand usage patterns. Specifically, ACR does **not** use this header for:
+
+- Authentication or authorization
+- Throttling, rate limiting, or quota calculations or exemptions
+- Request routing or prioritization
+- Any other business or control-plane logic
+
+Likewise, anything that observes or consumes this traffic or its telemetry — service meshes, proxies, gateways, traffic analyzers, monitoring systems, and business analytics dashboards or reports — should not take a trusted dependency on this header's value, since it is self-reported by the client.

--- a/docs/http-headers.md
+++ b/docs/http-headers.md
@@ -68,6 +68,7 @@ The values we ask ACR partners to use when populating the `X-Meta-Source-Client`
 | ACR Connected Registry         | `azure/acr/connected-registry/instance-1` |
 | Microsoft Defender for Cloud - ACR scanner that pulls images for vulnerability assessment | `azure/mdc/scanner-svc-image-puller`      |
 | Microsoft Defender for Cloud - ACR scanner for registry discovery and metadata            | `azure/mdc/scanner-svc-image-discovery`   |
+| Microsoft Defender for Cloud - ACR scanner for container image enrichment                 | `azure/mdc/scanner-svc-image-enrichment`  |
 | Microsoft Defender for Cloud - Azure DevOps CLI scanner that pulls images                 | `azure/mdc/scanner-ado-cli-image-puller`  |
 
 ## How ACR uses this header


### PR DESCRIPTION
Adds three new X-Meta-Source-Client header values for Microsoft Defender for Cloud scanners (image puller, image discovery, and ADO CLI image puller) to the header-values table. Also adds a new "How ACR uses this header" section clarifying that this header is unauthenticated, used only for telemetry and traffic analysis, and must not be relied upon for authentication, authorization, throttling, routing, or any other control-plane logic.